### PR TITLE
Feature/nullable optionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.0.1
+
+* New .proto file-level experimental options (all default to **false**):
+  - generate `DateTime` / Dart `Duration` getters/setters and autoconvert
+    these <-> google.protobuf.Timestamp / google.protobuf.Duration:
+    ```
+    option (dart_options.use_date_time) = true | false;
+    ```
+  - generate nullable optionals (`Type?` vs `Type`):
+    ```
+    option (dart_options.nullable_optionals) = true | false;
+    ```
+  - generate abstract interface classes (prefixed with 'I') for messages:
+    ```
+    option (dart_options.message_interfaces) = true | false;
+    ```
+
 ## 1.0.0
 
 * generate abstract interface class for each message prefixed with 'I' by default

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 This fork provides:
 - generation of abstract interface classes for messages;
+- generation of nullable optionals for non-required fields, with getter/setter wrappers (setting a field to `null` calls clearField());
 - generation of real Dart enums instead of classes with static constants;
 - generation of camelCased (instead of UPPER_SNAKE_CASED) enum values, but keeping the `name` field as the original UPPER_SNAKE_CASED String name from the proto.
 

--- a/lib/protoc.dart
+++ b/lib/protoc.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:protobuf/protobuf.dart';
 
 import 'const_generator.dart' show writeJsonConst;

--- a/lib/protoc.dart
+++ b/lib/protoc.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:protobuf/protobuf.dart';

--- a/lib/src/file_generator.dart
+++ b/lib/src/file_generator.dart
@@ -24,6 +24,18 @@ enum ProtoSyntax {
   proto3,
 }
 
+class GenOptions {
+  final bool messageInterfaces;
+  final bool nullableOptionals;
+  final bool useDateTime;
+
+  const GenOptions({
+    this.messageInterfaces = false,
+    this.nullableOptionals = false,
+    this.useDateTime = false,
+  });
+}
+
 /// Generates the Dart output files for one .proto input file.
 ///
 /// Outputs include .pb.dart, pbenum.dart, and .pbjson.dart.
@@ -160,6 +172,14 @@ class FileGenerator extends ProtobufContainer {
           '$defaultMixinName';
     }
 
+    final genOptions = GenOptions(
+      messageInterfaces:
+          descriptor.options.getExtension(Dart_options.messageInterfaces),
+      nullableOptionals:
+          descriptor.options.getExtension(Dart_options.nullableOptionals),
+      useDateTime: descriptor.options.getExtension(Dart_options.useDateTime),
+    );
+
     // Load and register all enum and message types.
     for (var i = 0; i < descriptor.enumType.length; i++) {
       enumGenerators.add(EnumGenerator.topLevel(
@@ -167,7 +187,8 @@ class FileGenerator extends ProtobufContainer {
     }
     for (var i = 0; i < descriptor.messageType.length; i++) {
       messageGenerators.add(MessageGenerator.topLevel(descriptor.messageType[i],
-          this, declaredMixins, defaultMixin, usedTopLevelNames, i));
+          this, declaredMixins, defaultMixin, usedTopLevelNames, i,
+          genOptions: genOptions));
     }
     for (var i = 0; i < descriptor.extension.length; i++) {
       extensionGenerators.add(ExtensionGenerator.topLevel(

--- a/lib/src/generated/dart_options.pb.dart
+++ b/lib/src/generated/dart_options.pb.dart
@@ -9,23 +9,7 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-/// A mixin that can be used in the 'with' clause of the generated Dart class
-/// for a proto message.
-abstract interface class IDartMixin {
-  /// The name of the mixin class.
-  $core.String get name;
-
-  /// A URI pointing to the Dart library that defines the mixin.
-  /// The generated Dart code will use this in an import statement.
-  $core.String get importFrom;
-
-  /// The name of another mixin to be applied ahead of this one.
-  /// The generated class for the message will inherit from all mixins
-  /// in the parent chain.
-  $core.String get parent;
-}
-
-class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
+class DartMixin extends $pb.GeneratedMessage {
   factory DartMixin({
     $core.String? name,
     $core.String? importFrom,
@@ -62,15 +46,19 @@ class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   DartMixin clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(DartMixin) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   DartMixin copyWith(void Function(DartMixin) updates) => rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static DartMixin create() => DartMixin._();
+  @$core.override
   DartMixin createEmptyInstance() => create();
   static $pb.PbList<DartMixin> createRepeated() => $pb.PbList<DartMixin>();
   @$core.pragma('dart2js:noInline')
@@ -79,7 +67,6 @@ class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
   static DartMixin? _defaultInstance;
 
   /// The name of the mixin class.
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -94,7 +81,6 @@ class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
 
   /// A URI pointing to the Dart library that defines the mixin.
   /// The generated Dart code will use this in an import statement.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get importFrom => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -110,7 +96,6 @@ class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
   /// The name of another mixin to be applied ahead of this one.
   /// The generated class for the message will inherit from all mixins
   /// in the parent chain.
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get parent => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -124,20 +109,7 @@ class DartMixin extends $pb.GeneratedMessage implements IDartMixin {
   void clearParent() => clearField(3);
 }
 
-/// Defines additional Dart imports to be used with messages in this file.
-abstract interface class IImports {
-  ///  Mixins to be used on messages in this file.
-  ///  These mixins are in addition to internally defined mixins (e.g PbMapMixin)
-  ///  and may override them.
-  ///
-  ///  Warning: mixins are experimental. The protoc Dart plugin doesn't check
-  ///  for name conflicts between mixin class members and generated class members,
-  ///  so the generated code may contain errors. Therefore, running dartanalyzer
-  ///  on the generated file is a good idea.
-  $core.List<IDartMixin> get mixins;
-}
-
-class Imports extends $pb.GeneratedMessage implements IImports {
+class Imports extends $pb.GeneratedMessage {
   factory Imports({
     $core.Iterable<DartMixin>? mixins,
   }) {
@@ -165,15 +137,19 @@ class Imports extends $pb.GeneratedMessage implements IImports {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   Imports clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(Imports) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   Imports copyWith(void Function(Imports) updates) => rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Imports create() => Imports._();
+  @$core.override
   Imports createEmptyInstance() => create();
   static $pb.PbList<Imports> createRepeated() => $pb.PbList<Imports>();
   @$core.pragma('dart2js:noInline')
@@ -189,7 +165,6 @@ class Imports extends $pb.GeneratedMessage implements IImports {
   ///  for name conflicts between mixin class members and generated class members,
   ///  so the generated code may contain errors. Therefore, running dartanalyzer
   ///  on the generated file is a good idea.
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<DartMixin> get mixins => $_getList(0);
 }
@@ -207,6 +182,21 @@ class Dart_options {
       _omitFieldNames ? '' : 'defaultMixin',
       96128839,
       $pb.PbFieldType.OS);
+  static final messageInterfaces = $pb.Extension<$core.bool>(
+      _omitMessageNames ? '' : 'google.protobuf.FileOptions',
+      _omitFieldNames ? '' : 'messageInterfaces',
+      71128890,
+      $pb.PbFieldType.OB);
+  static final nullableOptionals = $pb.Extension<$core.bool>(
+      _omitMessageNames ? '' : 'google.protobuf.FileOptions',
+      _omitFieldNames ? '' : 'nullableOptionals',
+      87148944,
+      $pb.PbFieldType.OB);
+  static final useDateTime = $pb.Extension<$core.bool>(
+      _omitMessageNames ? '' : 'google.protobuf.FileOptions',
+      _omitFieldNames ? '' : 'useDateTime',
+      50028268,
+      $pb.PbFieldType.OB);
   static final mixin = $pb.Extension<$core.String>(
       _omitMessageNames ? '' : 'google.protobuf.MessageOptions',
       _omitFieldNames ? '' : 'mixin',
@@ -240,6 +230,9 @@ class Dart_options {
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
     registry.add(imports);
     registry.add(defaultMixin);
+    registry.add(messageInterfaces);
+    registry.add(nullableOptionals);
+    registry.add(useDateTime);
     registry.add(mixin);
     registry.add(overrideGetter);
     registry.add(overrideSetter);

--- a/lib/src/generated/descriptor.pb.dart
+++ b/lib/src/generated/descriptor.pb.dart
@@ -14,14 +14,7 @@ import 'descriptor.pbenum.dart';
 
 export 'descriptor.pbenum.dart';
 
-/// The protocol compiler can output a FileDescriptorSet containing the .proto
-/// files it parses.
-abstract interface class IFileDescriptorSet {
-  $core.List<IFileDescriptorProto> get file;
-}
-
-class FileDescriptorSet extends $pb.GeneratedMessage
-    implements IFileDescriptorSet {
+class FileDescriptorSet extends $pb.GeneratedMessage {
   factory FileDescriptorSet({
     $core.Iterable<FileDescriptorProto>? file,
   }) {
@@ -50,17 +43,21 @@ class FileDescriptorSet extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   FileDescriptorSet clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(FileDescriptorSet) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet create() => FileDescriptorSet._();
+  @$core.override
   FileDescriptorSet createEmptyInstance() => create();
   static $pb.PbList<FileDescriptorSet> createRepeated() =>
       $pb.PbList<FileDescriptorSet>();
@@ -69,51 +66,11 @@ class FileDescriptorSet extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorSet>(create);
   static FileDescriptorSet? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<FileDescriptorProto> get file => $_getList(0);
 }
 
-/// Describes a complete .proto file.
-abstract interface class IFileDescriptorProto {
-  $core.String get name;
-
-  $core.String get package;
-
-  /// Names of files imported by this file.
-  $core.List<$core.String> get dependency;
-
-  /// All top-level definitions in this file.
-  $core.List<IDescriptorProto> get messageType;
-
-  $core.List<IEnumDescriptorProto> get enumType;
-
-  $core.List<IServiceDescriptorProto> get service;
-
-  $core.List<IFieldDescriptorProto> get extension;
-
-  IFileOptions get options;
-
-  /// This field contains optional information about the original source code.
-  /// You may safely remove this entire field without harming runtime
-  /// functionality of the descriptors -- the information is needed only by
-  /// development tools.
-  ISourceCodeInfo get sourceCodeInfo;
-
-  /// Indexes of the public imported files in the dependency list above.
-  $core.List<$core.int> get publicDependency;
-
-  /// Indexes of the weak imported files in the dependency list.
-  /// For Google-internal migration only. Do not use.
-  $core.List<$core.int> get weakDependency;
-
-  /// The syntax of the proto file.
-  /// The supported values are "proto2" and "proto3".
-  $core.String get syntax;
-}
-
-class FileDescriptorProto extends $pb.GeneratedMessage
-    implements IFileDescriptorProto {
+class FileDescriptorProto extends $pb.GeneratedMessage {
   factory FileDescriptorProto({
     $core.String? name,
     $core.String? package,
@@ -207,17 +164,21 @@ class FileDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   FileDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(FileDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto create() => FileDescriptorProto._();
+  @$core.override
   FileDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<FileDescriptorProto> createRepeated() =>
       $pb.PbList<FileDescriptorProto>();
@@ -226,7 +187,6 @@ class FileDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorProto>(create);
   static FileDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -239,7 +199,6 @@ class FileDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get package => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -253,28 +212,22 @@ class FileDescriptorProto extends $pb.GeneratedMessage
   void clearPackage() => clearField(2);
 
   /// Names of files imported by this file.
-  @$core.override
   @$pb.TagNumber(3)
   $core.List<$core.String> get dependency => $_getList(2);
 
   /// All top-level definitions in this file.
-  @$core.override
   @$pb.TagNumber(4)
   $core.List<DescriptorProto> get messageType => $_getList(3);
 
-  @$core.override
   @$pb.TagNumber(5)
   $core.List<EnumDescriptorProto> get enumType => $_getList(4);
 
-  @$core.override
   @$pb.TagNumber(6)
   $core.List<ServiceDescriptorProto> get service => $_getList(5);
 
-  @$core.override
   @$pb.TagNumber(7)
   $core.List<FieldDescriptorProto> get extension => $_getList(6);
 
-  @$core.override
   @$pb.TagNumber(8)
   FileOptions get options => $_getN(7);
   @$pb.TagNumber(8)
@@ -293,7 +246,6 @@ class FileDescriptorProto extends $pb.GeneratedMessage
   /// You may safely remove this entire field without harming runtime
   /// functionality of the descriptors -- the information is needed only by
   /// development tools.
-  @$core.override
   @$pb.TagNumber(9)
   SourceCodeInfo get sourceCodeInfo => $_getN(8);
   @$pb.TagNumber(9)
@@ -309,19 +261,16 @@ class FileDescriptorProto extends $pb.GeneratedMessage
   SourceCodeInfo ensureSourceCodeInfo() => $_ensure(8);
 
   /// Indexes of the public imported files in the dependency list above.
-  @$core.override
   @$pb.TagNumber(10)
   $core.List<$core.int> get publicDependency => $_getList(9);
 
   /// Indexes of the weak imported files in the dependency list.
   /// For Google-internal migration only. Do not use.
-  @$core.override
   @$pb.TagNumber(11)
   $core.List<$core.int> get weakDependency => $_getList(10);
 
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
-  @$core.override
   @$pb.TagNumber(12)
   $core.String get syntax => $_getSZ(11);
   @$pb.TagNumber(12)
@@ -335,16 +284,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage
   void clearSyntax() => clearField(12);
 }
 
-abstract interface class IDescriptorProto_ExtensionRange {
-  $core.int get start;
-
-  $core.int get end;
-
-  IExtensionRangeOptions get options;
-}
-
-class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
-    implements IDescriptorProto_ExtensionRange {
+class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   factory DescriptorProto_ExtensionRange({
     $core.int? start,
     $core.int? end,
@@ -382,19 +322,23 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto_ExtensionRange clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(DescriptorProto_ExtensionRange) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto_ExtensionRange copyWith(
           void Function(DescriptorProto_ExtensionRange) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange create() =>
       DescriptorProto_ExtensionRange._();
+  @$core.override
   DescriptorProto_ExtensionRange createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto_ExtensionRange> createRepeated() =>
       $pb.PbList<DescriptorProto_ExtensionRange>();
@@ -403,7 +347,6 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ExtensionRange>(create);
   static DescriptorProto_ExtensionRange? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
   @$pb.TagNumber(1)
@@ -416,7 +359,6 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearStart() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get end => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -429,7 +371,6 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
   @$pb.TagNumber(2)
   void clearEnd() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   ExtensionRangeOptions get options => $_getN(2);
   @$pb.TagNumber(3)
@@ -445,17 +386,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage
   ExtensionRangeOptions ensureOptions() => $_ensure(2);
 }
 
-/// Range of reserved tag numbers. Reserved tag numbers may not be used by
-/// fields or extension ranges in the same message. Reserved ranges may
-/// not overlap.
-abstract interface class IDescriptorProto_ReservedRange {
-  $core.int get start;
-
-  $core.int get end;
-}
-
-class DescriptorProto_ReservedRange extends $pb.GeneratedMessage
-    implements IDescriptorProto_ReservedRange {
+class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   factory DescriptorProto_ReservedRange({
     $core.int? start,
     $core.int? end,
@@ -488,19 +419,23 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto_ReservedRange clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(DescriptorProto_ReservedRange) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto_ReservedRange copyWith(
           void Function(DescriptorProto_ReservedRange) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange create() =>
       DescriptorProto_ReservedRange._();
+  @$core.override
   DescriptorProto_ReservedRange createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto_ReservedRange> createRepeated() =>
       $pb.PbList<DescriptorProto_ReservedRange>();
@@ -509,7 +444,6 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ReservedRange>(create);
   static DescriptorProto_ReservedRange? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
   @$pb.TagNumber(1)
@@ -522,7 +456,6 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearStart() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get end => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -536,32 +469,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage
   void clearEnd() => clearField(2);
 }
 
-/// Describes a message type.
-abstract interface class IDescriptorProto {
-  $core.String get name;
-
-  $core.List<IFieldDescriptorProto> get field;
-
-  $core.List<IDescriptorProto> get nestedType;
-
-  $core.List<IEnumDescriptorProto> get enumType;
-
-  $core.List<IDescriptorProto_ExtensionRange> get extensionRange;
-
-  $core.List<IFieldDescriptorProto> get extension;
-
-  IMessageOptions get options;
-
-  $core.List<IOneofDescriptorProto> get oneofDecl;
-
-  $core.List<IDescriptorProto_ReservedRange> get reservedRange;
-
-  /// Reserved field names, which may not be used by fields in the same message.
-  /// A given name may only be reserved once.
-  $core.List<$core.String> get reservedName;
-}
-
-class DescriptorProto extends $pb.GeneratedMessage implements IDescriptorProto {
+class DescriptorProto extends $pb.GeneratedMessage {
   factory DescriptorProto({
     $core.String? name,
     $core.Iterable<FieldDescriptorProto>? field,
@@ -648,17 +556,21 @@ class DescriptorProto extends $pb.GeneratedMessage implements IDescriptorProto {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(DescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static DescriptorProto create() => DescriptorProto._();
+  @$core.override
   DescriptorProto createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto> createRepeated() =>
       $pb.PbList<DescriptorProto>();
@@ -667,7 +579,6 @@ class DescriptorProto extends $pb.GeneratedMessage implements IDescriptorProto {
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto>(create);
   static DescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -680,27 +591,21 @@ class DescriptorProto extends $pb.GeneratedMessage implements IDescriptorProto {
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.List<FieldDescriptorProto> get field => $_getList(1);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.List<DescriptorProto> get nestedType => $_getList(2);
 
-  @$core.override
   @$pb.TagNumber(4)
   $core.List<EnumDescriptorProto> get enumType => $_getList(3);
 
-  @$core.override
   @$pb.TagNumber(5)
   $core.List<DescriptorProto_ExtensionRange> get extensionRange => $_getList(4);
 
-  @$core.override
   @$pb.TagNumber(6)
   $core.List<FieldDescriptorProto> get extension => $_getList(5);
 
-  @$core.override
   @$pb.TagNumber(7)
   MessageOptions get options => $_getN(6);
   @$pb.TagNumber(7)
@@ -715,28 +620,19 @@ class DescriptorProto extends $pb.GeneratedMessage implements IDescriptorProto {
   @$pb.TagNumber(7)
   MessageOptions ensureOptions() => $_ensure(6);
 
-  @$core.override
   @$pb.TagNumber(8)
   $core.List<OneofDescriptorProto> get oneofDecl => $_getList(7);
 
-  @$core.override
   @$pb.TagNumber(9)
   $core.List<DescriptorProto_ReservedRange> get reservedRange => $_getList(8);
 
   /// Reserved field names, which may not be used by fields in the same message.
   /// A given name may only be reserved once.
-  @$core.override
   @$pb.TagNumber(10)
   $core.List<$core.String> get reservedName => $_getList(9);
 }
 
-abstract interface class IExtensionRangeOptions {
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class ExtensionRangeOptions extends $pb.GeneratedMessage
-    implements IExtensionRangeOptions {
+class ExtensionRangeOptions extends $pb.GeneratedMessage {
   factory ExtensionRangeOptions({
     $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
@@ -766,18 +662,22 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   ExtensionRangeOptions clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(ExtensionRangeOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   ExtensionRangeOptions copyWith(
           void Function(ExtensionRangeOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExtensionRangeOptions create() => ExtensionRangeOptions._();
+  @$core.override
   ExtensionRangeOptions createEmptyInstance() => create();
   static $pb.PbList<ExtensionRangeOptions> createRepeated() =>
       $pb.PbList<ExtensionRangeOptions>();
@@ -787,79 +687,11 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage
   static ExtensionRangeOptions? _defaultInstance;
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
 }
 
-/// Describes a field within a message.
-abstract interface class IFieldDescriptorProto {
-  $core.String get name;
-
-  /// For extensions, this is the name of the type being extended.  It is
-  /// resolved in the same manner as type_name.
-  $core.String get extendee;
-
-  $core.int get number;
-
-  FieldDescriptorProto_Label get label;
-
-  /// If type_name is set, this need not be set.  If both this and type_name
-  /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
-  FieldDescriptorProto_Type get type;
-
-  /// For message and enum types, this is the name of the type.  If the name
-  /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-  /// rules are used to find the type (i.e. first the nested types within this
-  /// message are searched, then within the parent, on up to the root
-  /// namespace).
-  $core.String get typeName;
-
-  /// For numeric types, contains the original text representation of the value.
-  /// For booleans, "true" or "false".
-  /// For strings, contains the default text contents (not escaped in any way).
-  /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  /// TODO(kenton):  Base-64 encode?
-  $core.String get defaultValue;
-
-  IFieldOptions get options;
-
-  /// If set, gives the index of a oneof in the containing type's oneof_decl
-  /// list.  This field is a member of that oneof.
-  $core.int get oneofIndex;
-
-  /// JSON name of this field. The value is set by protocol compiler. If the
-  /// user has set a "json_name" option on this field, that option's value
-  /// will be used. Otherwise, it's deduced from the field's name by converting
-  /// it to camelCase.
-  $core.String get jsonName;
-
-  ///  If true, this is a proto3 "optional". When a proto3 field is optional, it
-  ///  tracks presence regardless of field type.
-  ///
-  ///  When proto3_optional is true, this field must be belong to a oneof to
-  ///  signal to old proto3 clients that presence is tracked for this field. This
-  ///  oneof is known as a "synthetic" oneof, and this field must be its sole
-  ///  member (each proto3 optional field gets its own synthetic oneof). Synthetic
-  ///  oneofs exist in the descriptor only, and do not generate any API. Synthetic
-  ///  oneofs must be ordered after all "real" oneofs.
-  ///
-  ///  For message fields, proto3_optional doesn't create any semantic change,
-  ///  since non-repeated message fields always track presence. However it still
-  ///  indicates the semantic detail of whether the user wrote "optional" or not.
-  ///  This can be useful for round-tripping the .proto file. For consistency we
-  ///  give message fields a synthetic oneof also, even though it is not required
-  ///  to track presence. This is especially important because the parser can't
-  ///  tell if a field is a message or an enum, so it must always create a
-  ///  synthetic oneof.
-  ///
-  ///  Proto2 optional fields do not set this flag, because they already indicate
-  ///  optional with `LABEL_OPTIONAL`.
-  $core.bool get proto3Optional;
-}
-
-class FieldDescriptorProto extends $pb.GeneratedMessage
-    implements IFieldDescriptorProto {
+class FieldDescriptorProto extends $pb.GeneratedMessage {
   factory FieldDescriptorProto({
     $core.String? name,
     $core.String? extendee,
@@ -945,17 +777,21 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   FieldDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(FieldDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto create() => FieldDescriptorProto._();
+  @$core.override
   FieldDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<FieldDescriptorProto> createRepeated() =>
       $pb.PbList<FieldDescriptorProto>();
@@ -964,7 +800,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<FieldDescriptorProto>(create);
   static FieldDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -979,7 +814,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
 
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get extendee => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -992,7 +826,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(2)
   void clearExtendee() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.int get number => $_getIZ(2);
   @$pb.TagNumber(3)
@@ -1005,7 +838,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(3)
   void clearNumber() => clearField(3);
 
-  @$core.override
   @$pb.TagNumber(4)
   FieldDescriptorProto_Label get label => $_getN(3);
   @$pb.TagNumber(4)
@@ -1020,7 +852,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
 
   /// If type_name is set, this need not be set.  If both this and type_name
   /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
-  @$core.override
   @$pb.TagNumber(5)
   FieldDescriptorProto_Type get type => $_getN(4);
   @$pb.TagNumber(5)
@@ -1038,7 +869,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   /// rules are used to find the type (i.e. first the nested types within this
   /// message are searched, then within the parent, on up to the root
   /// namespace).
-  @$core.override
   @$pb.TagNumber(6)
   $core.String get typeName => $_getSZ(5);
   @$pb.TagNumber(6)
@@ -1056,7 +886,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   /// For strings, contains the default text contents (not escaped in any way).
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
-  @$core.override
   @$pb.TagNumber(7)
   $core.String get defaultValue => $_getSZ(6);
   @$pb.TagNumber(7)
@@ -1069,7 +898,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(7)
   void clearDefaultValue() => clearField(7);
 
-  @$core.override
   @$pb.TagNumber(8)
   FieldOptions get options => $_getN(7);
   @$pb.TagNumber(8)
@@ -1086,7 +914,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
 
   /// If set, gives the index of a oneof in the containing type's oneof_decl
   /// list.  This field is a member of that oneof.
-  @$core.override
   @$pb.TagNumber(9)
   $core.int get oneofIndex => $_getIZ(8);
   @$pb.TagNumber(9)
@@ -1103,7 +930,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   /// user has set a "json_name" option on this field, that option's value
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
-  @$core.override
   @$pb.TagNumber(10)
   $core.String get jsonName => $_getSZ(9);
   @$pb.TagNumber(10)
@@ -1137,7 +963,6 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   ///
   ///  Proto2 optional fields do not set this flag, because they already indicate
   ///  optional with `LABEL_OPTIONAL`.
-  @$core.override
   @$pb.TagNumber(17)
   $core.bool get proto3Optional => $_getBF(10);
   @$pb.TagNumber(17)
@@ -1151,15 +976,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage
   void clearProto3Optional() => clearField(17);
 }
 
-/// Describes a oneof.
-abstract interface class IOneofDescriptorProto {
-  $core.String get name;
-
-  IOneofOptions get options;
-}
-
-class OneofDescriptorProto extends $pb.GeneratedMessage
-    implements IOneofDescriptorProto {
+class OneofDescriptorProto extends $pb.GeneratedMessage {
   factory OneofDescriptorProto({
     $core.String? name,
     OneofOptions? options,
@@ -1192,17 +1009,21 @@ class OneofDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   OneofDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(OneofDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto create() => OneofDescriptorProto._();
+  @$core.override
   OneofDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<OneofDescriptorProto> createRepeated() =>
       $pb.PbList<OneofDescriptorProto>();
@@ -1211,7 +1032,6 @@ class OneofDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<OneofDescriptorProto>(create);
   static OneofDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -1224,7 +1044,6 @@ class OneofDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   OneofOptions get options => $_getN(1);
   @$pb.TagNumber(2)
@@ -1240,20 +1059,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage
   OneofOptions ensureOptions() => $_ensure(1);
 }
 
-///  Range of reserved numeric values. Reserved values may not be used by
-///  entries in the same enum. Reserved ranges may not overlap.
-///
-///  Note that this is distinct from DescriptorProto.ReservedRange in that it
-///  is inclusive such that it can appropriately represent the entire int32
-///  domain.
-abstract interface class IEnumDescriptorProto_EnumReservedRange {
-  $core.int get start;
-
-  $core.int get end;
-}
-
-class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage
-    implements IEnumDescriptorProto_EnumReservedRange {
+class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
   factory EnumDescriptorProto_EnumReservedRange({
     $core.int? start,
     $core.int? end,
@@ -1287,19 +1093,23 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumDescriptorProto_EnumReservedRange clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(EnumDescriptorProto_EnumReservedRange) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumDescriptorProto_EnumReservedRange copyWith(
           void Function(EnumDescriptorProto_EnumReservedRange) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto_EnumReservedRange create() =>
       EnumDescriptorProto_EnumReservedRange._();
+  @$core.override
   EnumDescriptorProto_EnumReservedRange createEmptyInstance() => create();
   static $pb.PbList<EnumDescriptorProto_EnumReservedRange> createRepeated() =>
       $pb.PbList<EnumDescriptorProto_EnumReservedRange>();
@@ -1309,7 +1119,6 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage
           EnumDescriptorProto_EnumReservedRange>(create);
   static EnumDescriptorProto_EnumReservedRange? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
   @$pb.TagNumber(1)
@@ -1322,7 +1131,6 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearStart() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get end => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -1336,26 +1144,7 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage
   void clearEnd() => clearField(2);
 }
 
-/// Describes an enum type.
-abstract interface class IEnumDescriptorProto {
-  $core.String get name;
-
-  $core.List<IEnumValueDescriptorProto> get value;
-
-  IEnumOptions get options;
-
-  /// Range of reserved numeric values. Reserved numeric values may not be used
-  /// by enum values in the same enum declaration. Reserved ranges may not
-  /// overlap.
-  $core.List<IEnumDescriptorProto_EnumReservedRange> get reservedRange;
-
-  /// Reserved enum value names, which may not be reused. A given name may only
-  /// be reserved once.
-  $core.List<$core.String> get reservedName;
-}
-
-class EnumDescriptorProto extends $pb.GeneratedMessage
-    implements IEnumDescriptorProto {
+class EnumDescriptorProto extends $pb.GeneratedMessage {
   factory EnumDescriptorProto({
     $core.String? name,
     $core.Iterable<EnumValueDescriptorProto>? value,
@@ -1407,17 +1196,21 @@ class EnumDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(EnumDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto create() => EnumDescriptorProto._();
+  @$core.override
   EnumDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<EnumDescriptorProto> createRepeated() =>
       $pb.PbList<EnumDescriptorProto>();
@@ -1426,7 +1219,6 @@ class EnumDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<EnumDescriptorProto>(create);
   static EnumDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -1439,11 +1231,9 @@ class EnumDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.List<EnumValueDescriptorProto> get value => $_getList(1);
 
-  @$core.override
   @$pb.TagNumber(3)
   EnumOptions get options => $_getN(2);
   @$pb.TagNumber(3)
@@ -1461,29 +1251,17 @@ class EnumDescriptorProto extends $pb.GeneratedMessage
   /// Range of reserved numeric values. Reserved numeric values may not be used
   /// by enum values in the same enum declaration. Reserved ranges may not
   /// overlap.
-  @$core.override
   @$pb.TagNumber(4)
   $core.List<EnumDescriptorProto_EnumReservedRange> get reservedRange =>
       $_getList(3);
 
   /// Reserved enum value names, which may not be reused. A given name may only
   /// be reserved once.
-  @$core.override
   @$pb.TagNumber(5)
   $core.List<$core.String> get reservedName => $_getList(4);
 }
 
-/// Describes a value within an enum.
-abstract interface class IEnumValueDescriptorProto {
-  $core.String get name;
-
-  $core.int get number;
-
-  IEnumValueOptions get options;
-}
-
-class EnumValueDescriptorProto extends $pb.GeneratedMessage
-    implements IEnumValueDescriptorProto {
+class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   factory EnumValueDescriptorProto({
     $core.String? name,
     $core.int? number,
@@ -1521,18 +1299,22 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumValueDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(EnumValueDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumValueDescriptorProto copyWith(
           void Function(EnumValueDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto create() => EnumValueDescriptorProto._();
+  @$core.override
   EnumValueDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<EnumValueDescriptorProto> createRepeated() =>
       $pb.PbList<EnumValueDescriptorProto>();
@@ -1541,7 +1323,6 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<EnumValueDescriptorProto>(create);
   static EnumValueDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -1554,7 +1335,6 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get number => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -1567,7 +1347,6 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(2)
   void clearNumber() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   EnumValueOptions get options => $_getN(2);
   @$pb.TagNumber(3)
@@ -1583,17 +1362,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage
   EnumValueOptions ensureOptions() => $_ensure(2);
 }
 
-/// Describes a service.
-abstract interface class IServiceDescriptorProto {
-  $core.String get name;
-
-  $core.List<IMethodDescriptorProto> get method;
-
-  IServiceOptions get options;
-}
-
-class ServiceDescriptorProto extends $pb.GeneratedMessage
-    implements IServiceDescriptorProto {
+class ServiceDescriptorProto extends $pb.GeneratedMessage {
   factory ServiceDescriptorProto({
     $core.String? name,
     $core.Iterable<MethodDescriptorProto>? method,
@@ -1633,18 +1402,22 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   ServiceDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(ServiceDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   ServiceDescriptorProto copyWith(
           void Function(ServiceDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto create() => ServiceDescriptorProto._();
+  @$core.override
   ServiceDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<ServiceDescriptorProto> createRepeated() =>
       $pb.PbList<ServiceDescriptorProto>();
@@ -1653,7 +1426,6 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<ServiceDescriptorProto>(create);
   static ServiceDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -1666,11 +1438,9 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearName() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.List<MethodDescriptorProto> get method => $_getList(1);
 
-  @$core.override
   @$pb.TagNumber(3)
   ServiceOptions get options => $_getN(2);
   @$pb.TagNumber(3)
@@ -1686,27 +1456,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage
   ServiceOptions ensureOptions() => $_ensure(2);
 }
 
-/// Describes a method of a service.
-abstract interface class IMethodDescriptorProto {
-  $core.String get name;
-
-  /// Input and output type names.  These are resolved in the same way as
-  /// FieldDescriptorProto.type_name, but must refer to a message type.
-  $core.String get inputType;
-
-  $core.String get outputType;
-
-  IMethodOptions get options;
-
-  /// Identifies if client streams multiple client messages
-  $core.bool get clientStreaming;
-
-  /// Identifies if server streams multiple server messages
-  $core.bool get serverStreaming;
-}
-
-class MethodDescriptorProto extends $pb.GeneratedMessage
-    implements IMethodDescriptorProto {
+class MethodDescriptorProto extends $pb.GeneratedMessage {
   factory MethodDescriptorProto({
     $core.String? name,
     $core.String? inputType,
@@ -1759,18 +1509,22 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   MethodDescriptorProto clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(MethodDescriptorProto) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   MethodDescriptorProto copyWith(
           void Function(MethodDescriptorProto) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto create() => MethodDescriptorProto._();
+  @$core.override
   MethodDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<MethodDescriptorProto> createRepeated() =>
       $pb.PbList<MethodDescriptorProto>();
@@ -1779,7 +1533,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<MethodDescriptorProto>(create);
   static MethodDescriptorProto? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -1794,7 +1547,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
 
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get inputType => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -1807,7 +1559,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(2)
   void clearInputType() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get outputType => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -1820,7 +1571,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
   @$pb.TagNumber(3)
   void clearOutputType() => clearField(3);
 
-  @$core.override
   @$pb.TagNumber(4)
   MethodOptions get options => $_getN(3);
   @$pb.TagNumber(4)
@@ -1836,7 +1586,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
   MethodOptions ensureOptions() => $_ensure(3);
 
   /// Identifies if client streams multiple client messages
-  @$core.override
   @$pb.TagNumber(5)
   $core.bool get clientStreaming => $_getBF(4);
   @$pb.TagNumber(5)
@@ -1850,7 +1599,6 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
   void clearClientStreaming() => clearField(5);
 
   /// Identifies if server streams multiple server messages
-  @$core.override
   @$pb.TagNumber(6)
   $core.bool get serverStreaming => $_getBF(5);
   @$pb.TagNumber(6)
@@ -1864,115 +1612,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage
   void clearServerStreaming() => clearField(6);
 }
 
-abstract interface class IFileOptions {
-  /// Sets the Java package where classes generated from this .proto will be
-  /// placed.  By default, the proto package is used, but this is often
-  /// inappropriate because proto packages do not normally start with backwards
-  /// domain names.
-  $core.String get javaPackage;
-
-  /// If set, all the classes from the .proto file are wrapped in a single
-  /// outer class with the given name.  This applies to both Proto1
-  /// (equivalent to the old "--one_java_file" option) and Proto2 (where
-  /// a .proto always translates to a single class, but you may want to
-  /// explicitly choose the class name).
-  $core.String get javaOuterClassname;
-
-  FileOptions_OptimizeMode get optimizeFor;
-
-  /// If set true, then the Java code generator will generate a separate .java
-  /// file for each top-level message, enum, and service defined in the .proto
-  /// file.  Thus, these types will *not* be nested inside the outer class
-  /// named by java_outer_classname.  However, the outer class will still be
-  /// generated to contain the file's getDescriptor() method as well as any
-  /// top-level extensions defined in the file.
-  $core.bool get javaMultipleFiles;
-
-  /// Sets the Go package where structs generated from this .proto will be
-  /// placed. If omitted, the Go package will be derived from the following:
-  ///   - The basename of the package import path, if provided.
-  ///   - Otherwise, the package statement in the .proto file, if present.
-  ///   - Otherwise, the basename of the .proto file, without extension.
-  $core.String get goPackage;
-
-  ///  Should generic services be generated in each language?  "Generic" services
-  ///  are not specific to any particular RPC system.  They are generated by the
-  ///  main code generators in each language (without additional plugins).
-  ///  Generic services were the only kind of service generation supported by
-  ///  early versions of google.protobuf.
-  ///
-  ///  Generic services are now considered deprecated in favor of using plugins
-  ///  that generate code specific to your particular RPC system.  Therefore,
-  ///  these default to false.  Old code which depends on generic services should
-  ///  explicitly set them to true.
-  $core.bool get ccGenericServices;
-
-  $core.bool get javaGenericServices;
-
-  $core.bool get pyGenericServices;
-
-  /// This option does nothing.
-  @$core.Deprecated('This field is deprecated.')
-  $core.bool get javaGenerateEqualsAndHash;
-
-  /// Is this file deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for everything in the file, or it will be completely ignored; in the very
-  /// least, this is a formalization for deprecating files.
-  $core.bool get deprecated;
-
-  /// If set true, then the Java2 code generator will generate code that
-  /// throws an exception whenever an attempt is made to assign a non-UTF-8
-  /// byte sequence to a string field.
-  /// Message reflection will do the same.
-  /// However, an extension field still accepts non-UTF-8 byte sequences.
-  /// This option has no effect on when used with the lite runtime.
-  $core.bool get javaStringCheckUtf8;
-
-  /// Enables the use of arenas for the proto messages in this file. This applies
-  /// only to generated classes for C++.
-  $core.bool get ccEnableArenas;
-
-  /// Sets the objective c class prefix which is prepended to all objective c
-  /// generated classes from this .proto. There is no default.
-  $core.String get objcClassPrefix;
-
-  /// Namespace for generated classes; defaults to the package.
-  $core.String get csharpNamespace;
-
-  /// By default Swift generators will take the proto package and CamelCase it
-  /// replacing '.' with underscore and use that to prefix the types/symbols
-  /// defined. When this options is provided, they will use this value instead
-  /// to prefix the types/symbols defined.
-  $core.String get swiftPrefix;
-
-  /// Sets the php class prefix which is prepended to all php generated classes
-  /// from this .proto. Default is empty.
-  $core.String get phpClassPrefix;
-
-  /// Use this option to change the namespace of php generated classes. Default
-  /// is empty. When this option is empty, the package name will be used for
-  /// determining the namespace.
-  $core.String get phpNamespace;
-
-  $core.bool get phpGenericServices;
-
-  /// Use this option to change the namespace of php generated metadata classes.
-  /// Default is empty. When this option is empty, the proto file name will be
-  /// used for determining the namespace.
-  $core.String get phpMetadataNamespace;
-
-  /// Use this option to change the package of ruby generated classes. Default
-  /// is empty. When this option is not set, the package name will be used for
-  /// determining the ruby package.
-  $core.String get rubyPackage;
-
-  /// The parser stores options it doesn't recognize here.
-  /// See the documentation for the "Options" section above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
+class FileOptions extends $pb.GeneratedMessage {
   factory FileOptions({
     $core.String? javaPackage,
     $core.String? javaOuterClassname,
@@ -2110,15 +1750,19 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   FileOptions clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(FileOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   FileOptions copyWith(void Function(FileOptions) updates) => rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FileOptions create() => FileOptions._();
+  @$core.override
   FileOptions createEmptyInstance() => create();
   static $pb.PbList<FileOptions> createRepeated() => $pb.PbList<FileOptions>();
   @$core.pragma('dart2js:noInline')
@@ -2130,7 +1774,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// placed.  By default, the proto package is used, but this is often
   /// inappropriate because proto packages do not normally start with backwards
   /// domain names.
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get javaPackage => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -2148,7 +1791,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// (equivalent to the old "--one_java_file" option) and Proto2 (where
   /// a .proto always translates to a single class, but you may want to
   /// explicitly choose the class name).
-  @$core.override
   @$pb.TagNumber(8)
   $core.String get javaOuterClassname => $_getSZ(1);
   @$pb.TagNumber(8)
@@ -2161,7 +1803,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   @$pb.TagNumber(8)
   void clearJavaOuterClassname() => clearField(8);
 
-  @$core.override
   @$pb.TagNumber(9)
   FileOptions_OptimizeMode get optimizeFor => $_getN(2);
   @$pb.TagNumber(9)
@@ -2180,7 +1821,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// named by java_outer_classname.  However, the outer class will still be
   /// generated to contain the file's getDescriptor() method as well as any
   /// top-level extensions defined in the file.
-  @$core.override
   @$pb.TagNumber(10)
   $core.bool get javaMultipleFiles => $_getBF(3);
   @$pb.TagNumber(10)
@@ -2198,7 +1838,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   ///   - The basename of the package import path, if provided.
   ///   - Otherwise, the package statement in the .proto file, if present.
   ///   - Otherwise, the basename of the .proto file, without extension.
-  @$core.override
   @$pb.TagNumber(11)
   $core.String get goPackage => $_getSZ(4);
   @$pb.TagNumber(11)
@@ -2221,7 +1860,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   ///  that generate code specific to your particular RPC system.  Therefore,
   ///  these default to false.  Old code which depends on generic services should
   ///  explicitly set them to true.
-  @$core.override
   @$pb.TagNumber(16)
   $core.bool get ccGenericServices => $_getBF(5);
   @$pb.TagNumber(16)
@@ -2234,7 +1872,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   @$pb.TagNumber(16)
   void clearCcGenericServices() => clearField(16);
 
-  @$core.override
   @$pb.TagNumber(17)
   $core.bool get javaGenericServices => $_getBF(6);
   @$pb.TagNumber(17)
@@ -2247,7 +1884,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   @$pb.TagNumber(17)
   void clearJavaGenericServices() => clearField(17);
 
-  @$core.override
   @$pb.TagNumber(18)
   $core.bool get pyGenericServices => $_getBF(7);
   @$pb.TagNumber(18)
@@ -2262,7 +1898,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   /// This option does nothing.
   @$core.Deprecated('This field is deprecated.')
-  @$core.override
   @$pb.TagNumber(20)
   $core.bool get javaGenerateEqualsAndHash => $_getBF(8);
   @$core.Deprecated('This field is deprecated.')
@@ -2282,7 +1917,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for everything in the file, or it will be completely ignored; in the very
   /// least, this is a formalization for deprecating files.
-  @$core.override
   @$pb.TagNumber(23)
   $core.bool get deprecated => $_getBF(9);
   @$pb.TagNumber(23)
@@ -2301,7 +1935,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// Message reflection will do the same.
   /// However, an extension field still accepts non-UTF-8 byte sequences.
   /// This option has no effect on when used with the lite runtime.
-  @$core.override
   @$pb.TagNumber(27)
   $core.bool get javaStringCheckUtf8 => $_getBF(10);
   @$pb.TagNumber(27)
@@ -2316,7 +1949,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   /// Enables the use of arenas for the proto messages in this file. This applies
   /// only to generated classes for C++.
-  @$core.override
   @$pb.TagNumber(31)
   $core.bool get ccEnableArenas => $_getB(11, true);
   @$pb.TagNumber(31)
@@ -2331,7 +1963,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   /// Sets the objective c class prefix which is prepended to all objective c
   /// generated classes from this .proto. There is no default.
-  @$core.override
   @$pb.TagNumber(36)
   $core.String get objcClassPrefix => $_getSZ(12);
   @$pb.TagNumber(36)
@@ -2345,7 +1976,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   void clearObjcClassPrefix() => clearField(36);
 
   /// Namespace for generated classes; defaults to the package.
-  @$core.override
   @$pb.TagNumber(37)
   $core.String get csharpNamespace => $_getSZ(13);
   @$pb.TagNumber(37)
@@ -2362,7 +1992,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// replacing '.' with underscore and use that to prefix the types/symbols
   /// defined. When this options is provided, they will use this value instead
   /// to prefix the types/symbols defined.
-  @$core.override
   @$pb.TagNumber(39)
   $core.String get swiftPrefix => $_getSZ(14);
   @$pb.TagNumber(39)
@@ -2377,7 +2006,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   /// Sets the php class prefix which is prepended to all php generated classes
   /// from this .proto. Default is empty.
-  @$core.override
   @$pb.TagNumber(40)
   $core.String get phpClassPrefix => $_getSZ(15);
   @$pb.TagNumber(40)
@@ -2393,7 +2021,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// Use this option to change the namespace of php generated classes. Default
   /// is empty. When this option is empty, the package name will be used for
   /// determining the namespace.
-  @$core.override
   @$pb.TagNumber(41)
   $core.String get phpNamespace => $_getSZ(16);
   @$pb.TagNumber(41)
@@ -2406,7 +2033,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   @$pb.TagNumber(41)
   void clearPhpNamespace() => clearField(41);
 
-  @$core.override
   @$pb.TagNumber(42)
   $core.bool get phpGenericServices => $_getBF(17);
   @$pb.TagNumber(42)
@@ -2422,7 +2048,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// Use this option to change the namespace of php generated metadata classes.
   /// Default is empty. When this option is empty, the proto file name will be
   /// used for determining the namespace.
-  @$core.override
   @$pb.TagNumber(44)
   $core.String get phpMetadataNamespace => $_getSZ(18);
   @$pb.TagNumber(44)
@@ -2438,7 +2063,6 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
   /// Use this option to change the package of ruby generated classes. Default
   /// is empty. When this option is not set, the package name will be used for
   /// determining the ruby package.
-  @$core.override
   @$pb.TagNumber(45)
   $core.String get rubyPackage => $_getSZ(19);
   @$pb.TagNumber(45)
@@ -2453,71 +2077,11 @@ class FileOptions extends $pb.GeneratedMessage implements IFileOptions {
 
   /// The parser stores options it doesn't recognize here.
   /// See the documentation for the "Options" section above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(20);
 }
 
-abstract interface class IMessageOptions {
-  ///  Set true to use the old proto1 MessageSet wire format for extensions.
-  ///  This is provided for backwards-compatibility with the MessageSet wire
-  ///  format.  You should not use this for any other reason:  It's less
-  ///  efficient, has fewer features, and is more complicated.
-  ///
-  ///  The message must be defined exactly as follows:
-  ///    message Foo {
-  ///      option message_set_wire_format = true;
-  ///      extensions 4 to max;
-  ///    }
-  ///  Note that the message cannot have any defined fields; MessageSets only
-  ///  have extensions.
-  ///
-  ///  All extensions of your type must be singular messages; e.g. they cannot
-  ///  be int32s, enums, or repeated messages.
-  ///
-  ///  Because this is an option, the above two restrictions are not enforced by
-  ///  the protocol compiler.
-  $core.bool get messageSetWireFormat;
-
-  /// Disables the generation of the standard "descriptor()" accessor, which can
-  /// conflict with a field of the same name.  This is meant to make migration
-  /// from proto1 easier; new code should avoid fields named "descriptor".
-  $core.bool get noStandardDescriptorAccessor;
-
-  /// Is this message deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for the message, or it will be completely ignored; in the very least,
-  /// this is a formalization for deprecating messages.
-  $core.bool get deprecated;
-
-  ///  Whether the message is an automatically generated map entry type for the
-  ///  maps field.
-  ///
-  ///  For maps fields:
-  ///      map<KeyType, ValueType> map_field = 1;
-  ///  The parsed descriptor looks like:
-  ///      message MapFieldEntry {
-  ///          option map_entry = true;
-  ///          optional KeyType key = 1;
-  ///          optional ValueType value = 2;
-  ///      }
-  ///      repeated MapFieldEntry map_field = 1;
-  ///
-  ///  Implementations may choose not to generate the map_entry=true message, but
-  ///  use a native map in the target language to hold the keys and values.
-  ///  The reflection APIs in such implementations still need to work as
-  ///  if the field is a repeated message field.
-  ///
-  ///  NOTE: Do not set the option in .proto files. Always use the maps syntax
-  ///  instead. The option should only be implicitly set by the proto compiler
-  ///  parser.
-  $core.bool get mapEntry;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
+class MessageOptions extends $pb.GeneratedMessage {
   factory MessageOptions({
     $core.bool? messageSetWireFormat,
     $core.bool? noStandardDescriptorAccessor,
@@ -2567,17 +2131,21 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   MessageOptions clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(MessageOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static MessageOptions create() => MessageOptions._();
+  @$core.override
   MessageOptions createEmptyInstance() => create();
   static $pb.PbList<MessageOptions> createRepeated() =>
       $pb.PbList<MessageOptions>();
@@ -2604,7 +2172,6 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
   ///
   ///  Because this is an option, the above two restrictions are not enforced by
   ///  the protocol compiler.
-  @$core.override
   @$pb.TagNumber(1)
   $core.bool get messageSetWireFormat => $_getBF(0);
   @$pb.TagNumber(1)
@@ -2620,7 +2187,6 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
   /// Disables the generation of the standard "descriptor()" accessor, which can
   /// conflict with a field of the same name.  This is meant to make migration
   /// from proto1 easier; new code should avoid fields named "descriptor".
-  @$core.override
   @$pb.TagNumber(2)
   $core.bool get noStandardDescriptorAccessor => $_getBF(1);
   @$pb.TagNumber(2)
@@ -2637,7 +2203,6 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for the message, or it will be completely ignored; in the very least,
   /// this is a formalization for deprecating messages.
-  @$core.override
   @$pb.TagNumber(3)
   $core.bool get deprecated => $_getBF(2);
   @$pb.TagNumber(3)
@@ -2671,7 +2236,6 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
   ///  NOTE: Do not set the option in .proto files. Always use the maps syntax
   ///  instead. The option should only be implicitly set by the proto compiler
   ///  parser.
-  @$core.override
   @$pb.TagNumber(7)
   $core.bool get mapEntry => $_getBF(3);
   @$pb.TagNumber(7)
@@ -2685,82 +2249,11 @@ class MessageOptions extends $pb.GeneratedMessage implements IMessageOptions {
   void clearMapEntry() => clearField(7);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(4);
 }
 
-abstract interface class IFieldOptions {
-  /// The ctype option instructs the C++ code generator to use a different
-  /// representation of the field than it normally would.  See the specific
-  /// options below.  This option is not yet implemented in the open source
-  /// release -- sorry, we'll try to include it in a future version!
-  FieldOptions_CType get ctype;
-
-  /// The packed option can be enabled for repeated primitive fields to enable
-  /// a more efficient representation on the wire. Rather than repeatedly
-  /// writing the tag and type for each element, the entire array is encoded as
-  /// a single length-delimited blob. In proto3, only explicit setting it to
-  /// false will avoid using packed encoding.
-  $core.bool get packed;
-
-  /// Is this field deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for accessors, or it will be completely ignored; in the very least, this
-  /// is a formalization for deprecating fields.
-  $core.bool get deprecated;
-
-  ///  Should this field be parsed lazily?  Lazy applies only to message-type
-  ///  fields.  It means that when the outer message is initially parsed, the
-  ///  inner message's contents will not be parsed but instead stored in encoded
-  ///  form.  The inner message will actually be parsed when it is first accessed.
-  ///
-  ///  This is only a hint.  Implementations are free to choose whether to use
-  ///  eager or lazy parsing regardless of the value of this option.  However,
-  ///  setting this option true suggests that the protocol author believes that
-  ///  using lazy parsing on this field is worth the additional bookkeeping
-  ///  overhead typically needed to implement it.
-  ///
-  ///  This option does not affect the public interface of any generated code;
-  ///  all method signatures remain the same.  Furthermore, thread-safety of the
-  ///  interface is not affected by this option; const methods remain safe to
-  ///  call from multiple threads concurrently, while non-const methods continue
-  ///  to require exclusive access.
-  ///
-  ///
-  ///  Note that implementations may choose not to check required fields within
-  ///  a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  ///  may return true even if the inner message has missing required fields.
-  ///  This is necessary because otherwise the inner message would have to be
-  ///  parsed in order to perform the check, defeating the purpose of lazy
-  ///  parsing.  An implementation which chooses not to check required fields
-  ///  must be consistent about it.  That is, for any particular sub-message, the
-  ///  implementation must either *always* check its required fields, or *never*
-  ///  check its required fields, regardless of whether or not the message has
-  ///  been parsed.
-  $core.bool get lazy;
-
-  ///  The jstype option determines the JavaScript type used for values of the
-  ///  field.  The option is permitted only for 64 bit integral and fixed types
-  ///  (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-  ///  is represented as JavaScript string, which avoids loss of precision that
-  ///  can happen when a large value is converted to a floating point JavaScript.
-  ///  Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-  ///  use the JavaScript "number" type.  The behavior of the default option
-  ///  JS_NORMAL is implementation dependent.
-  ///
-  ///  This option is an enum to permit additional types to be added, e.g.
-  ///  goog.math.Integer.
-  FieldOptions_JSType get jstype;
-
-  /// For Google-internal migration only. Do not use.
-  $core.bool get weak;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
+class FieldOptions extends $pb.GeneratedMessage {
   factory FieldOptions({
     FieldOptions_CType? ctype,
     $core.bool? packed,
@@ -2828,16 +2321,20 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   FieldOptions clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(FieldOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static FieldOptions create() => FieldOptions._();
+  @$core.override
   FieldOptions createEmptyInstance() => create();
   static $pb.PbList<FieldOptions> createRepeated() =>
       $pb.PbList<FieldOptions>();
@@ -2850,7 +2347,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   /// representation of the field than it normally would.  See the specific
   /// options below.  This option is not yet implemented in the open source
   /// release -- sorry, we'll try to include it in a future version!
-  @$core.override
   @$pb.TagNumber(1)
   FieldOptions_CType get ctype => $_getN(0);
   @$pb.TagNumber(1)
@@ -2868,7 +2364,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   /// writing the tag and type for each element, the entire array is encoded as
   /// a single length-delimited blob. In proto3, only explicit setting it to
   /// false will avoid using packed encoding.
-  @$core.override
   @$pb.TagNumber(2)
   $core.bool get packed => $_getBF(1);
   @$pb.TagNumber(2)
@@ -2885,7 +2380,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for accessors, or it will be completely ignored; in the very least, this
   /// is a formalization for deprecating fields.
-  @$core.override
   @$pb.TagNumber(3)
   $core.bool get deprecated => $_getBF(2);
   @$pb.TagNumber(3)
@@ -2926,7 +2420,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   ///  implementation must either *always* check its required fields, or *never*
   ///  check its required fields, regardless of whether or not the message has
   ///  been parsed.
-  @$core.override
   @$pb.TagNumber(5)
   $core.bool get lazy => $_getBF(3);
   @$pb.TagNumber(5)
@@ -2950,7 +2443,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   ///
   ///  This option is an enum to permit additional types to be added, e.g.
   ///  goog.math.Integer.
-  @$core.override
   @$pb.TagNumber(6)
   FieldOptions_JSType get jstype => $_getN(4);
   @$pb.TagNumber(6)
@@ -2964,7 +2456,6 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   void clearJstype() => clearField(6);
 
   /// For Google-internal migration only. Do not use.
-  @$core.override
   @$pb.TagNumber(10)
   $core.bool get weak => $_getBF(5);
   @$pb.TagNumber(10)
@@ -2978,17 +2469,11 @@ class FieldOptions extends $pb.GeneratedMessage implements IFieldOptions {
   void clearWeak() => clearField(10);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(6);
 }
 
-abstract interface class IOneofOptions {
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class OneofOptions extends $pb.GeneratedMessage implements IOneofOptions {
+class OneofOptions extends $pb.GeneratedMessage {
   factory OneofOptions({
     $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
@@ -3018,16 +2503,20 @@ class OneofOptions extends $pb.GeneratedMessage implements IOneofOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   OneofOptions clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(OneofOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static OneofOptions create() => OneofOptions._();
+  @$core.override
   OneofOptions createEmptyInstance() => create();
   static $pb.PbList<OneofOptions> createRepeated() =>
       $pb.PbList<OneofOptions>();
@@ -3037,27 +2526,11 @@ class OneofOptions extends $pb.GeneratedMessage implements IOneofOptions {
   static OneofOptions? _defaultInstance;
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
 }
 
-abstract interface class IEnumOptions {
-  /// Set this option to true to allow mapping different tag names to the same
-  /// value.
-  $core.bool get allowAlias;
-
-  /// Is this enum deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for the enum, or it will be completely ignored; in the very least, this
-  /// is a formalization for deprecating enums.
-  $core.bool get deprecated;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class EnumOptions extends $pb.GeneratedMessage implements IEnumOptions {
+class EnumOptions extends $pb.GeneratedMessage {
   factory EnumOptions({
     $core.bool? allowAlias,
     $core.bool? deprecated,
@@ -3097,15 +2570,19 @@ class EnumOptions extends $pb.GeneratedMessage implements IEnumOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumOptions clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(EnumOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumOptions copyWith(void Function(EnumOptions) updates) => rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnumOptions create() => EnumOptions._();
+  @$core.override
   EnumOptions createEmptyInstance() => create();
   static $pb.PbList<EnumOptions> createRepeated() => $pb.PbList<EnumOptions>();
   @$core.pragma('dart2js:noInline')
@@ -3115,7 +2592,6 @@ class EnumOptions extends $pb.GeneratedMessage implements IEnumOptions {
 
   /// Set this option to true to allow mapping different tag names to the same
   /// value.
-  @$core.override
   @$pb.TagNumber(2)
   $core.bool get allowAlias => $_getBF(0);
   @$pb.TagNumber(2)
@@ -3132,7 +2608,6 @@ class EnumOptions extends $pb.GeneratedMessage implements IEnumOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for the enum, or it will be completely ignored; in the very least, this
   /// is a formalization for deprecating enums.
-  @$core.override
   @$pb.TagNumber(3)
   $core.bool get deprecated => $_getBF(1);
   @$pb.TagNumber(3)
@@ -3146,24 +2621,11 @@ class EnumOptions extends $pb.GeneratedMessage implements IEnumOptions {
   void clearDeprecated() => clearField(3);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(2);
 }
 
-abstract interface class IEnumValueOptions {
-  /// Is this enum value deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for the enum value, or it will be completely ignored; in the very least,
-  /// this is a formalization for deprecating enum values.
-  $core.bool get deprecated;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class EnumValueOptions extends $pb.GeneratedMessage
-    implements IEnumValueOptions {
+class EnumValueOptions extends $pb.GeneratedMessage {
   factory EnumValueOptions({
     $core.bool? deprecated,
     $core.Iterable<UninterpretedOption>? uninterpretedOption,
@@ -3198,17 +2660,21 @@ class EnumValueOptions extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumValueOptions clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(EnumValueOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions create() => EnumValueOptions._();
+  @$core.override
   EnumValueOptions createEmptyInstance() => create();
   static $pb.PbList<EnumValueOptions> createRepeated() =>
       $pb.PbList<EnumValueOptions>();
@@ -3221,7 +2687,6 @@ class EnumValueOptions extends $pb.GeneratedMessage
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for the enum value, or it will be completely ignored; in the very least,
   /// this is a formalization for deprecating enum values.
-  @$core.override
   @$pb.TagNumber(1)
   $core.bool get deprecated => $_getBF(0);
   @$pb.TagNumber(1)
@@ -3235,23 +2700,11 @@ class EnumValueOptions extends $pb.GeneratedMessage
   void clearDeprecated() => clearField(1);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(1);
 }
 
-abstract interface class IServiceOptions {
-  /// Is this service deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for the service, or it will be completely ignored; in the very least,
-  /// this is a formalization for deprecating services.
-  $core.bool get deprecated;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class ServiceOptions extends $pb.GeneratedMessage implements IServiceOptions {
+class ServiceOptions extends $pb.GeneratedMessage {
   factory ServiceOptions({
     $core.bool? deprecated,
     $core.Iterable<UninterpretedOption>? uninterpretedOption,
@@ -3286,17 +2739,21 @@ class ServiceOptions extends $pb.GeneratedMessage implements IServiceOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   ServiceOptions clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(ServiceOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ServiceOptions create() => ServiceOptions._();
+  @$core.override
   ServiceOptions createEmptyInstance() => create();
   static $pb.PbList<ServiceOptions> createRepeated() =>
       $pb.PbList<ServiceOptions>();
@@ -3309,7 +2766,6 @@ class ServiceOptions extends $pb.GeneratedMessage implements IServiceOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for the service, or it will be completely ignored; in the very least,
   /// this is a formalization for deprecating services.
-  @$core.override
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
   @$pb.TagNumber(33)
@@ -3323,25 +2779,11 @@ class ServiceOptions extends $pb.GeneratedMessage implements IServiceOptions {
   void clearDeprecated() => clearField(33);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(1);
 }
 
-abstract interface class IMethodOptions {
-  /// Is this method deprecated?
-  /// Depending on the target platform, this can emit Deprecated annotations
-  /// for the method, or it will be completely ignored; in the very least,
-  /// this is a formalization for deprecating methods.
-  $core.bool get deprecated;
-
-  MethodOptions_IdempotencyLevel get idempotencyLevel;
-
-  /// The parser stores options it doesn't recognize here. See above.
-  $core.List<IUninterpretedOption> get uninterpretedOption;
-}
-
-class MethodOptions extends $pb.GeneratedMessage implements IMethodOptions {
+class MethodOptions extends $pb.GeneratedMessage {
   factory MethodOptions({
     $core.bool? deprecated,
     MethodOptions_IdempotencyLevel? idempotencyLevel,
@@ -3385,17 +2827,21 @@ class MethodOptions extends $pb.GeneratedMessage implements IMethodOptions {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   MethodOptions clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(MethodOptions) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static MethodOptions create() => MethodOptions._();
+  @$core.override
   MethodOptions createEmptyInstance() => create();
   static $pb.PbList<MethodOptions> createRepeated() =>
       $pb.PbList<MethodOptions>();
@@ -3408,7 +2854,6 @@ class MethodOptions extends $pb.GeneratedMessage implements IMethodOptions {
   /// Depending on the target platform, this can emit Deprecated annotations
   /// for the method, or it will be completely ignored; in the very least,
   /// this is a formalization for deprecating methods.
-  @$core.override
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
   @$pb.TagNumber(33)
@@ -3421,7 +2866,6 @@ class MethodOptions extends $pb.GeneratedMessage implements IMethodOptions {
   @$pb.TagNumber(33)
   void clearDeprecated() => clearField(33);
 
-  @$core.override
   @$pb.TagNumber(34)
   MethodOptions_IdempotencyLevel get idempotencyLevel => $_getN(1);
   @$pb.TagNumber(34)
@@ -3435,24 +2879,11 @@ class MethodOptions extends $pb.GeneratedMessage implements IMethodOptions {
   void clearIdempotencyLevel() => clearField(34);
 
   /// The parser stores options it doesn't recognize here. See above.
-  @$core.override
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(2);
 }
 
-/// The name of the uninterpreted option.  Each string represents a segment in
-/// a dot-separated name.  is_extension is true iff a segment represents an
-/// extension (denoted with parentheses in options specs in .proto files).
-/// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-/// "foo.(bar.baz).qux".
-abstract interface class IUninterpretedOption_NamePart {
-  $core.String get namePart;
-
-  $core.bool get isExtension;
-}
-
-class UninterpretedOption_NamePart extends $pb.GeneratedMessage
-    implements IUninterpretedOption_NamePart {
+class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   factory UninterpretedOption_NamePart({
     $core.String? namePart,
     $core.bool? isExtension,
@@ -3485,19 +2916,23 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   UninterpretedOption_NamePart clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(UninterpretedOption_NamePart) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   UninterpretedOption_NamePart copyWith(
           void Function(UninterpretedOption_NamePart) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart create() =>
       UninterpretedOption_NamePart._();
+  @$core.override
   UninterpretedOption_NamePart createEmptyInstance() => create();
   static $pb.PbList<UninterpretedOption_NamePart> createRepeated() =>
       $pb.PbList<UninterpretedOption_NamePart>();
@@ -3506,7 +2941,6 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption_NamePart>(create);
   static UninterpretedOption_NamePart? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get namePart => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -3519,7 +2953,6 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage
   @$pb.TagNumber(1)
   void clearNamePart() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.bool get isExtension => $_getBF(1);
   @$pb.TagNumber(2)
@@ -3533,32 +2966,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage
   void clearIsExtension() => clearField(2);
 }
 
-/// A message representing a option the parser does not recognize. This only
-/// appears in options protos created by the compiler::Parser class.
-/// DescriptorPool resolves these when building Descriptor objects. Therefore,
-/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
-/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-/// in them.
-abstract interface class IUninterpretedOption {
-  $core.List<IUninterpretedOption_NamePart> get name;
-
-  /// The value of the uninterpreted option, in whatever type the tokenizer
-  /// identified it as during parsing. Exactly one of these should be set.
-  $core.String get identifierValue;
-
-  $fixnum.Int64 get positiveIntValue;
-
-  $fixnum.Int64 get negativeIntValue;
-
-  $core.double get doubleValue;
-
-  $core.List<$core.int> get stringValue;
-
-  $core.String get aggregateValue;
-}
-
-class UninterpretedOption extends $pb.GeneratedMessage
-    implements IUninterpretedOption {
+class UninterpretedOption extends $pb.GeneratedMessage {
   factory UninterpretedOption({
     $core.Iterable<UninterpretedOption_NamePart>? name,
     $core.String? identifierValue,
@@ -3621,17 +3029,21 @@ class UninterpretedOption extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   UninterpretedOption clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(UninterpretedOption) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption create() => UninterpretedOption._();
+  @$core.override
   UninterpretedOption createEmptyInstance() => create();
   static $pb.PbList<UninterpretedOption> createRepeated() =>
       $pb.PbList<UninterpretedOption>();
@@ -3640,13 +3052,11 @@ class UninterpretedOption extends $pb.GeneratedMessage
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption>(create);
   static UninterpretedOption? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.List<UninterpretedOption_NamePart> get name => $_getList(0);
 
   /// The value of the uninterpreted option, in whatever type the tokenizer
   /// identified it as during parsing. Exactly one of these should be set.
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get identifierValue => $_getSZ(1);
   @$pb.TagNumber(3)
@@ -3659,7 +3069,6 @@ class UninterpretedOption extends $pb.GeneratedMessage
   @$pb.TagNumber(3)
   void clearIdentifierValue() => clearField(3);
 
-  @$core.override
   @$pb.TagNumber(4)
   $fixnum.Int64 get positiveIntValue => $_getI64(2);
   @$pb.TagNumber(4)
@@ -3672,7 +3081,6 @@ class UninterpretedOption extends $pb.GeneratedMessage
   @$pb.TagNumber(4)
   void clearPositiveIntValue() => clearField(4);
 
-  @$core.override
   @$pb.TagNumber(5)
   $fixnum.Int64 get negativeIntValue => $_getI64(3);
   @$pb.TagNumber(5)
@@ -3685,7 +3093,6 @@ class UninterpretedOption extends $pb.GeneratedMessage
   @$pb.TagNumber(5)
   void clearNegativeIntValue() => clearField(5);
 
-  @$core.override
   @$pb.TagNumber(6)
   $core.double get doubleValue => $_getN(4);
   @$pb.TagNumber(6)
@@ -3698,7 +3105,6 @@ class UninterpretedOption extends $pb.GeneratedMessage
   @$pb.TagNumber(6)
   void clearDoubleValue() => clearField(6);
 
-  @$core.override
   @$pb.TagNumber(7)
   $core.List<$core.int> get stringValue => $_getN(5);
   @$pb.TagNumber(7)
@@ -3711,7 +3117,6 @@ class UninterpretedOption extends $pb.GeneratedMessage
   @$pb.TagNumber(7)
   void clearStringValue() => clearField(7);
 
-  @$core.override
   @$pb.TagNumber(8)
   $core.String get aggregateValue => $_getSZ(6);
   @$pb.TagNumber(8)
@@ -3725,95 +3130,7 @@ class UninterpretedOption extends $pb.GeneratedMessage
   void clearAggregateValue() => clearField(8);
 }
 
-abstract interface class ISourceCodeInfo_Location {
-  ///  Identifies which part of the FileDescriptorProto was defined at this
-  ///  location.
-  ///
-  ///  Each element is a field number or an index.  They form a path from
-  ///  the root FileDescriptorProto to the place where the definition.  For
-  ///  example, this path:
-  ///    [ 4, 3, 2, 7, 1 ]
-  ///  refers to:
-  ///    file.message_type(3)  // 4, 3
-  ///        .field(7)         // 2, 7
-  ///        .name()           // 1
-  ///  This is because FileDescriptorProto.message_type has field number 4:
-  ///    repeated DescriptorProto message_type = 4;
-  ///  and DescriptorProto.field has field number 2:
-  ///    repeated FieldDescriptorProto field = 2;
-  ///  and FieldDescriptorProto.name has field number 1:
-  ///    optional string name = 1;
-  ///
-  ///  Thus, the above path gives the location of a field name.  If we removed
-  ///  the last element:
-  ///    [ 4, 3, 2, 7 ]
-  ///  this path refers to the whole field declaration (from the beginning
-  ///  of the label to the terminating semicolon).
-  $core.List<$core.int> get path;
-
-  /// Always has exactly three or four elements: start line, start column,
-  /// end line (optional, otherwise assumed same as start line), end column.
-  /// These are packed into a single field for efficiency.  Note that line
-  /// and column numbers are zero-based -- typically you will want to add
-  /// 1 to each before displaying to a user.
-  $core.List<$core.int> get span;
-
-  ///  If this SourceCodeInfo represents a complete declaration, these are any
-  ///  comments appearing before and after the declaration which appear to be
-  ///  attached to the declaration.
-  ///
-  ///  A series of line comments appearing on consecutive lines, with no other
-  ///  tokens appearing on those lines, will be treated as a single comment.
-  ///
-  ///  leading_detached_comments will keep paragraphs of comments that appear
-  ///  before (but not connected to) the current element. Each paragraph,
-  ///  separated by empty lines, will be one comment element in the repeated
-  ///  field.
-  ///
-  ///  Only the comment content is provided; comment markers (e.g. //) are
-  ///  stripped out.  For block comments, leading whitespace and an asterisk
-  ///  will be stripped from the beginning of each line other than the first.
-  ///  Newlines are included in the output.
-  ///
-  ///  Examples:
-  ///
-  ///    optional int32 foo = 1;  // Comment attached to foo.
-  ///    // Comment attached to bar.
-  ///    optional int32 bar = 2;
-  ///
-  ///    optional string baz = 3;
-  ///    // Comment attached to baz.
-  ///    // Another line attached to baz.
-  ///
-  ///    // Comment attached to qux.
-  ///    //
-  ///    // Another line attached to qux.
-  ///    optional double qux = 4;
-  ///
-  ///    // Detached comment for corge. This is not leading or trailing comments
-  ///    // to qux or corge because there are blank lines separating it from
-  ///    // both.
-  ///
-  ///    // Detached comment for corge paragraph 2.
-  ///
-  ///    optional string corge = 5;
-  ///    /* Block comment attached
-  ///     * to corge.  Leading asterisks
-  ///     * will be removed. */
-  ///    /* Block comment attached to
-  ///     * grault. */
-  ///    optional int32 grault = 6;
-  ///
-  ///    // ignored detached comments.
-  $core.String get leadingComments;
-
-  $core.String get trailingComments;
-
-  $core.List<$core.String> get leadingDetachedComments;
-}
-
-class SourceCodeInfo_Location extends $pb.GeneratedMessage
-    implements ISourceCodeInfo_Location {
+class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   factory SourceCodeInfo_Location({
     $core.Iterable<$core.int>? path,
     $core.Iterable<$core.int>? span,
@@ -3861,18 +3178,22 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   SourceCodeInfo_Location clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(SourceCodeInfo_Location) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   SourceCodeInfo_Location copyWith(
           void Function(SourceCodeInfo_Location) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location create() => SourceCodeInfo_Location._();
+  @$core.override
   SourceCodeInfo_Location createEmptyInstance() => create();
   static $pb.PbList<SourceCodeInfo_Location> createRepeated() =>
       $pb.PbList<SourceCodeInfo_Location>();
@@ -3904,7 +3225,6 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
   ///    [ 4, 3, 2, 7 ]
   ///  this path refers to the whole field declaration (from the beginning
   ///  of the label to the terminating semicolon).
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
 
@@ -3913,7 +3233,6 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
   /// These are packed into a single field for efficiency.  Note that line
   /// and column numbers are zero-based -- typically you will want to add
   /// 1 to each before displaying to a user.
-  @$core.override
   @$pb.TagNumber(2)
   $core.List<$core.int> get span => $_getList(1);
 
@@ -3964,7 +3283,6 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
   ///    optional int32 grault = 6;
   ///
   ///    // ignored detached comments.
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get leadingComments => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -3977,7 +3295,6 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
   @$pb.TagNumber(3)
   void clearLeadingComments() => clearField(3);
 
-  @$core.override
   @$pb.TagNumber(4)
   $core.String get trailingComments => $_getSZ(3);
   @$pb.TagNumber(4)
@@ -3990,61 +3307,11 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage
   @$pb.TagNumber(4)
   void clearTrailingComments() => clearField(4);
 
-  @$core.override
   @$pb.TagNumber(6)
   $core.List<$core.String> get leadingDetachedComments => $_getList(4);
 }
 
-/// Encapsulates information about the original source file from which a
-/// FileDescriptorProto was generated.
-abstract interface class ISourceCodeInfo {
-  ///  A Location identifies a piece of source code in a .proto file which
-  ///  corresponds to a particular definition.  This information is intended
-  ///  to be useful to IDEs, code indexers, documentation generators, and similar
-  ///  tools.
-  ///
-  ///  For example, say we have a file like:
-  ///    message Foo {
-  ///      optional string foo = 1;
-  ///    }
-  ///  Let's look at just the field definition:
-  ///    optional string foo = 1;
-  ///    ^       ^^     ^^  ^  ^^^
-  ///    a       bc     de  f  ghi
-  ///  We have the following locations:
-  ///    span   path               represents
-  ///    [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-  ///    [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-  ///    [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-  ///    [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-  ///    [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
-  ///
-  ///  Notes:
-  ///  - A location may refer to a repeated field itself (i.e. not to any
-  ///    particular index within it).  This is used whenever a set of elements are
-  ///    logically enclosed in a single code segment.  For example, an entire
-  ///    extend block (possibly containing multiple extension definitions) will
-  ///    have an outer location whose path refers to the "extensions" repeated
-  ///    field without an index.
-  ///  - Multiple locations may have the same path.  This happens when a single
-  ///    logical declaration is spread out across multiple places.  The most
-  ///    obvious example is the "extend" block again -- there may be multiple
-  ///    extend blocks in the same scope, each of which will have the same path.
-  ///  - A location's span is not always a subset of its parent's span.  For
-  ///    example, the "extendee" of an extension declaration appears at the
-  ///    beginning of the "extend" block and is shared by all extensions within
-  ///    the block.
-  ///  - Just because a location's span is a subset of some other location's span
-  ///    does not mean that it is a descendant.  For example, a "group" defines
-  ///    both a type and a field in a single declaration.  Thus, the locations
-  ///    corresponding to the type and field and their components will overlap.
-  ///  - Code which tries to interpret locations should probably be designed to
-  ///    ignore those that it doesn't understand, as more types of locations could
-  ///    be recorded in the future.
-  $core.List<ISourceCodeInfo_Location> get location;
-}
-
-class SourceCodeInfo extends $pb.GeneratedMessage implements ISourceCodeInfo {
+class SourceCodeInfo extends $pb.GeneratedMessage {
   factory SourceCodeInfo({
     $core.Iterable<SourceCodeInfo_Location>? location,
   }) {
@@ -4074,17 +3341,21 @@ class SourceCodeInfo extends $pb.GeneratedMessage implements ISourceCodeInfo {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   SourceCodeInfo clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(SourceCodeInfo) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo create() => SourceCodeInfo._();
+  @$core.override
   SourceCodeInfo createEmptyInstance() => create();
   static $pb.PbList<SourceCodeInfo> createRepeated() =>
       $pb.PbList<SourceCodeInfo>();
@@ -4136,31 +3407,11 @@ class SourceCodeInfo extends $pb.GeneratedMessage implements ISourceCodeInfo {
   ///  - Code which tries to interpret locations should probably be designed to
   ///    ignore those that it doesn't understand, as more types of locations could
   ///    be recorded in the future.
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<SourceCodeInfo_Location> get location => $_getList(0);
 }
 
-abstract interface class IGeneratedCodeInfo_Annotation {
-  /// Identifies the element in the original source .proto file. This field
-  /// is formatted the same as SourceCodeInfo.Location.path.
-  $core.List<$core.int> get path;
-
-  /// Identifies the filesystem path to the original source .proto.
-  $core.String get sourceFile;
-
-  /// Identifies the starting offset in bytes in the generated code
-  /// that relates to the identified object.
-  $core.int get begin;
-
-  /// Identifies the ending offset in bytes in the generated code that
-  /// relates to the identified offset. The end offset should be one past
-  /// the last relevant byte (so the length of the text = end - begin).
-  $core.int get end;
-}
-
-class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
-    implements IGeneratedCodeInfo_Annotation {
+class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   factory GeneratedCodeInfo_Annotation({
     $core.Iterable<$core.int>? path,
     $core.String? sourceFile,
@@ -4203,19 +3454,23 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   GeneratedCodeInfo_Annotation clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(GeneratedCodeInfo_Annotation) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   GeneratedCodeInfo_Annotation copyWith(
           void Function(GeneratedCodeInfo_Annotation) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation create() =>
       GeneratedCodeInfo_Annotation._();
+  @$core.override
   GeneratedCodeInfo_Annotation createEmptyInstance() => create();
   static $pb.PbList<GeneratedCodeInfo_Annotation> createRepeated() =>
       $pb.PbList<GeneratedCodeInfo_Annotation>();
@@ -4226,12 +3481,10 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
 
   /// Identifies the element in the original source .proto file. This field
   /// is formatted the same as SourceCodeInfo.Location.path.
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
 
   /// Identifies the filesystem path to the original source .proto.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get sourceFile => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -4246,7 +3499,6 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
 
   /// Identifies the starting offset in bytes in the generated code
   /// that relates to the identified object.
-  @$core.override
   @$pb.TagNumber(3)
   $core.int get begin => $_getIZ(2);
   @$pb.TagNumber(3)
@@ -4262,7 +3514,6 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
   /// Identifies the ending offset in bytes in the generated code that
   /// relates to the identified offset. The end offset should be one past
   /// the last relevant byte (so the length of the text = end - begin).
-  @$core.override
   @$pb.TagNumber(4)
   $core.int get end => $_getIZ(3);
   @$pb.TagNumber(4)
@@ -4276,17 +3527,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage
   void clearEnd() => clearField(4);
 }
 
-/// Describes the relationship between generated code and its original source
-/// file. A GeneratedCodeInfo message is associated with only one generated
-/// source file, but may contain references to different source .proto files.
-abstract interface class IGeneratedCodeInfo {
-  /// An Annotation connects some span of text in generated code to an element
-  /// of its generating .proto file.
-  $core.List<IGeneratedCodeInfo_Annotation> get annotation;
-}
-
-class GeneratedCodeInfo extends $pb.GeneratedMessage
-    implements IGeneratedCodeInfo {
+class GeneratedCodeInfo extends $pb.GeneratedMessage {
   factory GeneratedCodeInfo({
     $core.Iterable<GeneratedCodeInfo_Annotation>? annotation,
   }) {
@@ -4316,17 +3557,21 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   GeneratedCodeInfo clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(GeneratedCodeInfo) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo create() => GeneratedCodeInfo._();
+  @$core.override
   GeneratedCodeInfo createEmptyInstance() => create();
   static $pb.PbList<GeneratedCodeInfo> createRepeated() =>
       $pb.PbList<GeneratedCodeInfo>();
@@ -4337,7 +3582,6 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage
 
   /// An Annotation connects some span of text in generated code to an element
   /// of its generating .proto file.
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);
 }

--- a/lib/src/generated/plugin.pb.dart
+++ b/lib/src/generated/plugin.pb.dart
@@ -14,20 +14,7 @@ import 'descriptor.pb.dart' as $0;
 
 export 'plugin.pbenum.dart';
 
-/// The version number of protocol compiler.
-abstract interface class IVersion {
-  $core.int get major;
-
-  $core.int get minor;
-
-  $core.int get patch;
-
-  /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-  /// be empty for mainline stable releases.
-  $core.String get suffix;
-}
-
-class Version extends $pb.GeneratedMessage implements IVersion {
+class Version extends $pb.GeneratedMessage {
   factory Version({
     $core.int? major,
     $core.int? minor,
@@ -70,15 +57,19 @@ class Version extends $pb.GeneratedMessage implements IVersion {
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   Version clone() => deepCopy();
   @$core.Deprecated('Use rebuild(void Function(Version) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   Version copyWith(void Function(Version) updates) => rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Version create() => Version._();
+  @$core.override
   Version createEmptyInstance() => create();
   static $pb.PbList<Version> createRepeated() => $pb.PbList<Version>();
   @$core.pragma('dart2js:noInline')
@@ -86,7 +77,6 @@ class Version extends $pb.GeneratedMessage implements IVersion {
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Version>(create);
   static Version? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.int get major => $_getIZ(0);
   @$pb.TagNumber(1)
@@ -99,7 +89,6 @@ class Version extends $pb.GeneratedMessage implements IVersion {
   @$pb.TagNumber(1)
   void clearMajor() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get minor => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -112,7 +101,6 @@ class Version extends $pb.GeneratedMessage implements IVersion {
   @$pb.TagNumber(2)
   void clearMinor() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.int get patch => $_getIZ(2);
   @$pb.TagNumber(3)
@@ -127,7 +115,6 @@ class Version extends $pb.GeneratedMessage implements IVersion {
 
   /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
   /// be empty for mainline stable releases.
-  @$core.override
   @$pb.TagNumber(4)
   $core.String get suffix => $_getSZ(3);
   @$pb.TagNumber(4)
@@ -141,38 +128,7 @@ class Version extends $pb.GeneratedMessage implements IVersion {
   void clearSuffix() => clearField(4);
 }
 
-/// An encoded CodeGeneratorRequest is written to the plugin's stdin.
-abstract interface class ICodeGeneratorRequest {
-  /// The .proto files that were explicitly listed on the command-line.  The
-  /// code generator should generate code only for these files.  Each file's
-  /// descriptor will be included in proto_file, below.
-  $core.List<$core.String> get fileToGenerate;
-
-  /// The generator parameter passed on the command-line.
-  $core.String get parameter;
-
-  /// The version number of protocol compiler.
-  IVersion get compilerVersion;
-
-  ///  FileDescriptorProtos for all files in files_to_generate and everything
-  ///  they import.  The files will appear in topological order, so each file
-  ///  appears before any file that imports it.
-  ///
-  ///  protoc guarantees that all proto_files will be written after
-  ///  the fields above, even though this is not technically guaranteed by the
-  ///  protobuf wire format.  This theoretically could allow a plugin to stream
-  ///  in the FileDescriptorProtos and handle them one by one rather than read
-  ///  the entire set into memory at once.  However, as of this writing, this
-  ///  is not similarly optimized on protoc's end -- it will store all fields in
-  ///  memory at once before sending them to the plugin.
-  ///
-  ///  Type names of fields and extensions in the FileDescriptorProto are always
-  ///  fully qualified.
-  $core.List<$0.IFileDescriptorProto> get protoFile;
-}
-
-class CodeGeneratorRequest extends $pb.GeneratedMessage
-    implements ICodeGeneratorRequest {
+class CodeGeneratorRequest extends $pb.GeneratedMessage {
   factory CodeGeneratorRequest({
     $core.Iterable<$core.String>? fileToGenerate,
     $core.String? parameter,
@@ -217,17 +173,21 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorRequest clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(CodeGeneratorRequest) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest create() => CodeGeneratorRequest._();
+  @$core.override
   CodeGeneratorRequest createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorRequest> createRepeated() =>
       $pb.PbList<CodeGeneratorRequest>();
@@ -239,12 +199,10 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage
   /// The .proto files that were explicitly listed on the command-line.  The
   /// code generator should generate code only for these files.  Each file's
   /// descriptor will be included in proto_file, below.
-  @$core.override
   @$pb.TagNumber(1)
   $core.List<$core.String> get fileToGenerate => $_getList(0);
 
   /// The generator parameter passed on the command-line.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get parameter => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -258,7 +216,6 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage
   void clearParameter() => clearField(2);
 
   /// The version number of protocol compiler.
-  @$core.override
   @$pb.TagNumber(3)
   Version get compilerVersion => $_getN(2);
   @$pb.TagNumber(3)
@@ -287,76 +244,11 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage
   ///
   ///  Type names of fields and extensions in the FileDescriptorProto are always
   ///  fully qualified.
-  @$core.override
   @$pb.TagNumber(15)
   $core.List<$0.FileDescriptorProto> get protoFile => $_getList(3);
 }
 
-/// Represents a single generated file.
-abstract interface class ICodeGeneratorResponse_File {
-  ///  The file name, relative to the output directory.  The name must not
-  ///  contain "." or ".." components and must be relative, not be absolute (so,
-  ///  the file cannot lie outside the output directory).  "/" must be used as
-  ///  the path separator, not "\".
-  ///
-  ///  If the name is omitted, the content will be appended to the previous
-  ///  file.  This allows the generator to break large files into small chunks,
-  ///  and allows the generated text to be streamed back to protoc so that large
-  ///  files need not reside completely in memory at one time.  Note that as of
-  ///  this writing protoc does not optimize for this -- it will read the entire
-  ///  CodeGeneratorResponse before writing files to disk.
-  $core.String get name;
-
-  ///  If non-empty, indicates that the named file should already exist, and the
-  ///  content here is to be inserted into that file at a defined insertion
-  ///  point.  This feature allows a code generator to extend the output
-  ///  produced by another code generator.  The original generator may provide
-  ///  insertion points by placing special annotations in the file that look
-  ///  like:
-  ///    @@protoc_insertion_point(NAME)
-  ///  The annotation can have arbitrary text before and after it on the line,
-  ///  which allows it to be placed in a comment.  NAME should be replaced with
-  ///  an identifier naming the point -- this is what other generators will use
-  ///  as the insertion_point.  Code inserted at this point will be placed
-  ///  immediately above the line containing the insertion point (thus multiple
-  ///  insertions to the same point will come out in the order they were added).
-  ///  The double-@ is intended to make it unlikely that the generated code
-  ///  could contain things that look like insertion points by accident.
-  ///
-  ///  For example, the C++ code generator places the following line in the
-  ///  .pb.h files that it generates:
-  ///    // @@protoc_insertion_point(namespace_scope)
-  ///  This line appears within the scope of the file's package namespace, but
-  ///  outside of any particular class.  Another plugin can then specify the
-  ///  insertion_point "namespace_scope" to generate additional classes or
-  ///  other declarations that should be placed in this scope.
-  ///
-  ///  Note that if the line containing the insertion point begins with
-  ///  whitespace, the same whitespace will be added to every line of the
-  ///  inserted text.  This is useful for languages like Python, where
-  ///  indentation matters.  In these languages, the insertion point comment
-  ///  should be indented the same amount as any inserted code will need to be
-  ///  in order to work correctly in that context.
-  ///
-  ///  The code generator that generates the initial file and the one which
-  ///  inserts into it must both run as part of a single invocation of protoc.
-  ///  Code generators are executed in the order in which they appear on the
-  ///  command line.
-  ///
-  ///  If |insertion_point| is present, |name| must also be present.
-  $core.String get insertionPoint;
-
-  /// The file contents.
-  $core.String get content;
-
-  /// Information describing the file content being inserted. If an insertion
-  /// point is used, this information will be appropriately offset and inserted
-  /// into the code generation metadata for the generated files.
-  $0.IGeneratedCodeInfo get generatedCodeInfo;
-}
-
-class CodeGeneratorResponse_File extends $pb.GeneratedMessage
-    implements ICodeGeneratorResponse_File {
+class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   factory CodeGeneratorResponse_File({
     $core.String? name,
     $core.String? insertionPoint,
@@ -400,18 +292,22 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorResponse_File clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(CodeGeneratorResponse_File) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorResponse_File copyWith(
           void Function(CodeGeneratorResponse_File) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File create() => CodeGeneratorResponse_File._();
+  @$core.override
   CodeGeneratorResponse_File createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorResponse_File> createRepeated() =>
       $pb.PbList<CodeGeneratorResponse_File>();
@@ -431,7 +327,6 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
   ///  files need not reside completely in memory at one time.  Note that as of
   ///  this writing protoc does not optimize for this -- it will read the entire
   ///  CodeGeneratorResponse before writing files to disk.
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -481,7 +376,6 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
   ///  command line.
   ///
   ///  If |insertion_point| is present, |name| must also be present.
-  @$core.override
   @$pb.TagNumber(2)
   $core.String get insertionPoint => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -495,7 +389,6 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
   void clearInsertionPoint() => clearField(2);
 
   /// The file contents.
-  @$core.override
   @$pb.TagNumber(15)
   $core.String get content => $_getSZ(2);
   @$pb.TagNumber(15)
@@ -511,7 +404,6 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
   /// Information describing the file content being inserted. If an insertion
   /// point is used, this information will be appropriately offset and inserted
   /// into the code generation metadata for the generated files.
-  @$core.override
   @$pb.TagNumber(16)
   $0.GeneratedCodeInfo get generatedCodeInfo => $_getN(3);
   @$pb.TagNumber(16)
@@ -527,27 +419,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage
   $0.GeneratedCodeInfo ensureGeneratedCodeInfo() => $_ensure(3);
 }
 
-/// The plugin writes an encoded CodeGeneratorResponse to stdout.
-abstract interface class ICodeGeneratorResponse {
-  ///  Error message.  If non-empty, code generation failed.  The plugin process
-  ///  should exit with status code zero even if it reports an error in this way.
-  ///
-  ///  This should be used to indicate errors in .proto files which prevent the
-  ///  code generator from generating correct code.  Errors which indicate a
-  ///  problem in protoc itself -- such as the input CodeGeneratorRequest being
-  ///  unparseable -- should be reported by writing a message to stderr and
-  ///  exiting with a non-zero status code.
-  $core.String get error;
-
-  /// A bitmask of supported features that the code generator supports.
-  /// This is a bitwise "or" of values from the Feature enum.
-  $fixnum.Int64 get supportedFeatures;
-
-  $core.List<ICodeGeneratorResponse_File> get file;
-}
-
-class CodeGeneratorResponse extends $pb.GeneratedMessage
-    implements ICodeGeneratorResponse {
+class CodeGeneratorResponse extends $pb.GeneratedMessage {
   factory CodeGeneratorResponse({
     $core.String? error,
     $fixnum.Int64? supportedFeatures,
@@ -589,18 +461,22 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage
 
   @$core.Deprecated('Use deepCopy() instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorResponse clone() => deepCopy();
   @$core.Deprecated(
       'Use rebuild(void Function(CodeGeneratorResponse) updates) instead. '
       'Will be removed in next major version')
+  @$core.override
   CodeGeneratorResponse copyWith(
           void Function(CodeGeneratorResponse) updates) =>
       rebuild(updates);
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse create() => CodeGeneratorResponse._();
+  @$core.override
   CodeGeneratorResponse createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorResponse> createRepeated() =>
       $pb.PbList<CodeGeneratorResponse>();
@@ -617,7 +493,6 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage
   ///  problem in protoc itself -- such as the input CodeGeneratorRequest being
   ///  unparseable -- should be reported by writing a message to stderr and
   ///  exiting with a non-zero status code.
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get error => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -632,7 +507,6 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage
 
   /// A bitmask of supported features that the code generator supports.
   /// This is a bitwise "or" of values from the Feature enum.
-  @$core.override
   @$pb.TagNumber(2)
   $fixnum.Int64 get supportedFeatures => $_getI64(1);
   @$pb.TagNumber(2)
@@ -645,7 +519,6 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage
   @$pb.TagNumber(2)
   void clearSupportedFeatures() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(15)
   $core.List<CodeGeneratorResponse_File> get file => $_getList(2);
 }

--- a/lib/src/shared.dart
+++ b/lib/src/shared.dart
@@ -12,6 +12,7 @@ const asyncImportPrefix = r'$async';
 const coreImportPrefix = r'$core';
 const grpcImportPrefix = r'$grpc';
 const mixinImportPrefix = r'$mixin';
+const overridePrefix = '@$coreImportPrefix.override';
 
 extension FileDescriptorProtoExt on FileGenerator {
   String? commentBlock(List<int> path) {

--- a/lib/src/well_known_types.dart
+++ b/lib/src/well_known_types.dart
@@ -7,6 +7,8 @@ part of '../protoc.dart';
 PbMixin? wellKnownMixinForFullName(String qualifiedName) =>
     _wellKnownMixins[qualifiedName];
 
+Map<String, PbMixin> get wellKnownMixins => _wellKnownMixins;
+
 const _wellKnownImportPath =
     'package:protobuf/src/protobuf/mixins/well_known.dart';
 

--- a/protos/dart_options.proto
+++ b/protos/dart_options.proto
@@ -48,6 +48,19 @@ extend google.protobuf.FileOptions {
   // (May be overridden by the "mixin" option on a message.)
   // For now, "PbMapMixin" is the only available mixin.
   optional string default_mixin = 96128839;
+
+  // Experimental option that causes the generator to generate
+  // abstract interface classes for messages.
+  optional bool message_interfaces = 71128890 [default = false];
+
+  // Experimental option that causes the generator to generate
+  // nullable optional fields.
+  optional bool nullable_optionals = 87148944 [default = false];
+
+  // Experimental option that causes the generator to generate
+  // Dart DateTime / Duration getters/setters and auto-convert
+  // these <-> google.protobuf.Timestamp / google.protobuf.Duration.
+  optional bool use_date_time = 50028268 [default = false];
 }
 
 extend google.protobuf.MessageOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: better_protoc_plugin
-version: 1.0.0
+version: 1.0.1
 description: A better protobuf protoc compiler plugin used to generate Dart code.
 repository: https://github.com/dra11y/better_protoc_plugin
 
@@ -10,9 +10,9 @@ dependencies:
   fixnum: ^1.0.0
   path: ^1.8.0
   protobuf: ^3.1.0
+  collection: ^1.15.0
 
 dev_dependencies:
-  collection: ^1.15.0
   dart_flutter_team_lints: ^2.1.0
   matcher: ^0.12.10
   test: ^1.16.0

--- a/test/goldens/grpc_service.pb
+++ b/test/goldens/grpc_service.pb
@@ -9,10 +9,7 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-abstract interface class IEmpty {
-}
-
-class Empty extends $pb.GeneratedMessage implements IEmpty {
+class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
   Empty._() : super();
   factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -25,17 +22,17 @@ class Empty extends $pb.GeneratedMessage implements IEmpty {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  Empty clone() => deepCopy();
+  @$core.override Empty clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(Empty) updates) instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => rebuild(updates);
+  @$core.override Empty copyWith(void Function(Empty) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
-  Empty createEmptyInstance() => create();
+  @$core.override Empty createEmptyInstance() => create();
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);

--- a/test/goldens/imports.pb
+++ b/test/goldens/imports.pb
@@ -12,16 +12,7 @@ import 'package:protobuf/protobuf.dart' as $pb;
 import 'package1.pb.dart' as $1;
 import 'package2.pb.dart' as $2;
 
-abstract interface class IM {
-
-  IM get m;
-
-  $1.IM get m1;
-
-  $2.IM get m2;
-}
-
-class M extends $pb.GeneratedMessage implements IM {
+class M extends $pb.GeneratedMessage {
   factory M() => create();
   M._() : super();
   factory M.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -37,23 +28,22 @@ class M extends $pb.GeneratedMessage implements IM {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  M clone() => deepCopy();
+  @$core.override M clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(M) updates) instead. '
   'Will be removed in next major version')
-  M copyWith(void Function(M) updates) => rebuild(updates);
+  @$core.override M copyWith(void Function(M) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static M create() => M._();
-  M createEmptyInstance() => create();
+  @$core.override M createEmptyInstance() => create();
   static $pb.PbList<M> createRepeated() => $pb.PbList<M>();
   @$core.pragma('dart2js:noInline')
   static M getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<M>(create);
   static M? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   M get m => $_getN(0);
   @$pb.TagNumber(1)
@@ -65,7 +55,6 @@ class M extends $pb.GeneratedMessage implements IM {
   @$pb.TagNumber(1)
   M ensureM() => $_ensure(0);
 
-  @$core.override
   @$pb.TagNumber(2)
   $1.M get m1 => $_getN(1);
   @$pb.TagNumber(2)
@@ -77,7 +66,6 @@ class M extends $pb.GeneratedMessage implements IM {
   @$pb.TagNumber(2)
   $1.M ensureM1() => $_ensure(1);
 
-  @$core.override
   @$pb.TagNumber(3)
   $2.M get m2 => $_getN(2);
   @$pb.TagNumber(3)

--- a/test/goldens/int64.pb
+++ b/test/goldens/int64.pb
@@ -10,12 +10,7 @@ import 'dart:core' as $core;
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
-abstract interface class IInt64 {
-
-  $fixnum.Int64 get value;
-}
-
-class Int64 extends $pb.GeneratedMessage implements IInt64 {
+class Int64 extends $pb.GeneratedMessage {
   factory Int64() => create();
   Int64._() : super();
   factory Int64.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -29,23 +24,22 @@ class Int64 extends $pb.GeneratedMessage implements IInt64 {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  Int64 clone() => deepCopy();
+  @$core.override Int64 clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(Int64) updates) instead. '
   'Will be removed in next major version')
-  Int64 copyWith(void Function(Int64) updates) => rebuild(updates);
+  @$core.override Int64 copyWith(void Function(Int64) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Int64 create() => Int64._();
-  Int64 createEmptyInstance() => create();
+  @$core.override Int64 createEmptyInstance() => create();
   static $pb.PbList<Int64> createRepeated() => $pb.PbList<Int64>();
   @$core.pragma('dart2js:noInline')
   static Int64 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int64>(create);
   static Int64? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);
   @$pb.TagNumber(1)

--- a/test/goldens/messageGenerator
+++ b/test/goldens/messageGenerator
@@ -1,16 +1,4 @@
-abstract interface class IPhoneNumber {
-
-  $core.String get number;
-
-  PhoneNumber_PhoneType get type;
-
-  $core.String get name;
-
-  @$core.Deprecated('This field is deprecated.')
-  $core.String get deprecatedField;
-}
-
-class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
+class PhoneNumber extends $pb.GeneratedMessage {
   factory PhoneNumber() => create();
   PhoneNumber._() : super();
   factory PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -26,23 +14,22 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  PhoneNumber clone() => deepCopy();
+  @$core.override PhoneNumber clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(PhoneNumber) updates) instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => rebuild(updates);
+  @$core.override PhoneNumber copyWith(void Function(PhoneNumber) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
-  PhoneNumber createEmptyInstance() => create();
+  @$core.override PhoneNumber createEmptyInstance() => create();
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
   static PhoneNumber? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -52,7 +39,6 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$pb.TagNumber(1)
   void clearNumber() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   PhoneNumber_PhoneType get type => $_getN(1);
   @$pb.TagNumber(2)
@@ -62,7 +48,6 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$pb.TagNumber(2)
   void clearType() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get name => $_getS(2, '\$');
   @$pb.TagNumber(3)
@@ -73,7 +58,6 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   void clearName() => clearField(3);
 
   @$core.Deprecated('This field is deprecated.')
-  @$core.override
   @$pb.TagNumber(4)
   $core.String get deprecatedField => $_getSZ(3);
   @$core.Deprecated('This field is deprecated.')

--- a/test/goldens/messageGenerator.meta
+++ b/test/goldens/messageGenerator.meta
@@ -2,8 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 25
-  end: 37
+  begin: 6
+  end: 17
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: 
+  begin: 88
+  end: 99
 }
 annotation: {
   path: 4
@@ -11,49 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 60
-  end: 66
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: 
-  begin: 97
-  end: 101
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 2
-  sourceFile: 
-  begin: 123
-  end: 127
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 198
-  end: 213
-}
-annotation: {
-  path: 4
-  path: 0
-  sourceFile: 
-  begin: 224
-  end: 235
-}
-annotation: {
-  path: 4
-  path: 0
-  sourceFile: 
-  begin: 330
-  end: 341
+  begin: 1825
+  end: 1831
 }
 annotation: {
   path: 4
@@ -61,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2021
-  end: 2027
+  begin: 1873
+  end: 1879
 }
 annotation: {
   path: 4
@@ -70,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2069
-  end: 2075
+  begin: 1952
+  end: 1961
 }
 annotation: {
   path: 4
@@ -79,17 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2148
-  end: 2157
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: 
-  begin: 2200
-  end: 2211
+  begin: 2004
+  end: 2015
 }
 annotation: {
   path: 4
@@ -97,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2299
-  end: 2303
+  begin: 2085
+  end: 2089
 }
 annotation: {
   path: 4
@@ -106,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2344
-  end: 2348
+  begin: 2130
+  end: 2134
 }
 annotation: {
   path: 4
@@ -115,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2427
-  end: 2434
+  begin: 2213
+  end: 2220
 }
 annotation: {
   path: 4
@@ -124,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2477
-  end: 2486
+  begin: 2263
+  end: 2272
 }
 annotation: {
   path: 4
@@ -133,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2565
-  end: 2569
+  begin: 2333
+  end: 2337
 }
 annotation: {
   path: 4
@@ -142,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2616
-  end: 2620
+  begin: 2384
+  end: 2388
 }
 annotation: {
   path: 4
@@ -151,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2693
-  end: 2700
+  begin: 2461
+  end: 2468
 }
 annotation: {
   path: 4
@@ -160,8 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2743
-  end: 2752
+  begin: 2511
+  end: 2520
 }
 annotation: {
   path: 4
@@ -169,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2880
-  end: 2895
+  begin: 2630
+  end: 2645
 }
 annotation: {
   path: 4
@@ -178,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2986
-  end: 3001
+  begin: 2736
+  end: 2751
 }
 annotation: {
   path: 4
@@ -187,8 +144,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3123
-  end: 3141
+  begin: 2873
+  end: 2891
 }
 annotation: {
   path: 4
@@ -196,6 +153,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3233
-  end: 3253
+  begin: 2983
+  end: 3003
 }

--- a/test/goldens/oneMessage.pb
+++ b/test/goldens/oneMessage.pb
@@ -9,16 +9,7 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-abstract interface class IPhoneNumber {
-
-  $core.String get number;
-
-  $core.int get type;
-
-  $core.String get name;
-}
-
-class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
+class PhoneNumber extends $pb.GeneratedMessage {
   factory PhoneNumber() => create();
   PhoneNumber._() : super();
   factory PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -33,23 +24,22 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  PhoneNumber clone() => deepCopy();
+  @$core.override PhoneNumber clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(PhoneNumber) updates) instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => rebuild(updates);
+  @$core.override PhoneNumber copyWith(void Function(PhoneNumber) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
-  PhoneNumber createEmptyInstance() => create();
+  @$core.override PhoneNumber createEmptyInstance() => create();
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
   static PhoneNumber? _defaultInstance;
 
-  @$core.override
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -59,7 +49,6 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$pb.TagNumber(1)
   void clearNumber() => clearField(1);
 
-  @$core.override
   @$pb.TagNumber(2)
   $core.int get type => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -69,7 +58,6 @@ class PhoneNumber extends $pb.GeneratedMessage implements IPhoneNumber {
   @$pb.TagNumber(2)
   void clearType() => clearField(2);
 
-  @$core.override
   @$pb.TagNumber(3)
   $core.String get name => $_getS(2, '\$');
   @$pb.TagNumber(3)

--- a/test/goldens/oneMessage.pb.meta
+++ b/test/goldens/oneMessage.pb.meta
@@ -2,8 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 203
-  end: 215
+  begin: 184
+  end: 195
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: test
+  begin: 266
+  end: 277
 }
 annotation: {
   path: 4
@@ -11,40 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 238
-  end: 244
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 263
-  end: 267
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 2
-  sourceFile: test
-  begin: 289
-  end: 293
-}
-annotation: {
-  path: 4
-  path: 0
-  sourceFile: test
-  begin: 304
-  end: 315
-}
-annotation: {
-  path: 4
-  path: 0
-  sourceFile: test
-  begin: 410
-  end: 421
+  begin: 1808
+  end: 1814
 }
 annotation: {
   path: 4
@@ -52,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1906
-  end: 1912
+  begin: 1856
+  end: 1862
 }
 annotation: {
   path: 4
@@ -61,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1954
-  end: 1960
+  begin: 1935
+  end: 1944
 }
 annotation: {
   path: 4
@@ -70,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2033
-  end: 2042
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2085
-  end: 2096
+  begin: 1987
+  end: 1998
 }
 annotation: {
   path: 4
@@ -88,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2172
-  end: 2176
+  begin: 2056
+  end: 2060
 }
 annotation: {
   path: 4
@@ -97,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2218
-  end: 2222
+  begin: 2102
+  end: 2106
 }
 annotation: {
   path: 4
@@ -106,8 +72,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2297
-  end: 2304
+  begin: 2181
+  end: 2188
 }
 annotation: {
   path: 4
@@ -115,7 +81,25 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2347
+  begin: 2231
+  end: 2240
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 2301
+  end: 2305
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 2352
   end: 2356
 }
 annotation: {
@@ -124,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2435
-  end: 2439
+  begin: 2429
+  end: 2436
 }
 annotation: {
   path: 4
@@ -133,24 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2486
-  end: 2490
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 2
-  sourceFile: test
-  begin: 2563
-  end: 2570
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 2
-  sourceFile: test
-  begin: 2613
-  end: 2622
+  begin: 2479
+  end: 2488
 }

--- a/test/goldens/service.pb
+++ b/test/goldens/service.pb
@@ -10,10 +10,7 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-abstract interface class IEmpty {
-}
-
-class Empty extends $pb.GeneratedMessage implements IEmpty {
+class Empty extends $pb.GeneratedMessage {
   factory Empty() => create();
   Empty._() : super();
   factory Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
@@ -26,17 +23,17 @@ class Empty extends $pb.GeneratedMessage implements IEmpty {
   @$core.Deprecated(
   'Use deepCopy() instead. '
   'Will be removed in next major version')
-  Empty clone() => deepCopy();
+  @$core.override Empty clone() => deepCopy();
   @$core.Deprecated(
   'Use rebuild(void Function(Empty) updates) instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => rebuild(updates);
+  @$core.override Empty copyWith(void Function(Empty) updates) => rebuild(updates);
 
-  $pb.BuilderInfo get info_ => _i;
+  @$core.override $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
-  Empty createEmptyInstance() => create();
+  @$core.override Empty createEmptyInstance() => create();
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);


### PR DESCRIPTION
## 1.0.1

* New .proto file-level experimental options (all default to **false**):
  - generate `DateTime` / Dart `Duration` getters/setters and autoconvert
    these <-> google.protobuf.Timestamp / google.protobuf.Duration:
    ```
    option (dart_options.use_date_time) = true | false;
    ```
  - generate nullable optionals (`Type?` vs `Type`):
    ```
    option (dart_options.nullable_optionals) = true | false;
    ```
  - generate abstract interface classes (prefixed with 'I') for messages:
    ```
    option (dart_options.message_interfaces) = true | false;
    ```

